### PR TITLE
【iOS】収入・支出グラフ表示機能の追加

### DIFF
--- a/project/iOS/imitate.xcodeproj/project.pbxproj
+++ b/project/iOS/imitate.xcodeproj/project.pbxproj
@@ -73,6 +73,9 @@
 		B9C191CA2EFFF4C500AFE3C3 /* BalanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191C92EFFF4C500AFE3C3 /* BalanceView.swift */; };
 		B9C191CB2EFFF4C500AFE3C3 /* BalanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191C92EFFF4C500AFE3C3 /* BalanceView.swift */; };
 		B9C191CC2EFFF4C500AFE3C3 /* BalanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191C92EFFF4C500AFE3C3 /* BalanceView.swift */; };
+		B9C191D12F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */; };
+		B9C191D22F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */; };
+		B9C191D32F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */; };
 		B9C191CE2F081E9400AFE3C3 /* BalanceRecordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191CD2F081E9400AFE3C3 /* BalanceRecordRepository.swift */; };
 		B9C191CF2F081E9400AFE3C3 /* BalanceRecordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191CD2F081E9400AFE3C3 /* BalanceRecordRepository.swift */; };
 		B9C191D02F081E9400AFE3C3 /* BalanceRecordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191CD2F081E9400AFE3C3 /* BalanceRecordRepository.swift */; };
@@ -152,6 +155,7 @@
 		B9C191C02EFFDE4E00AFE3C3 /* HistoryHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHomeView.swift; sourceTree = "<group>"; };
 		B9C191C42EFFDE6400AFE3C3 /* SettingHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingHomeView.swift; sourceTree = "<group>"; };
 		B9C191C92EFFF4C500AFE3C3 /* BalanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceView.swift; sourceTree = "<group>"; };
+		B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceGraphView.swift; sourceTree = "<group>"; };
 		B9C191CD2F081E9400AFE3C3 /* BalanceRecordRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceRecordRepository.swift; sourceTree = "<group>"; };
 		B9D08D2F2E520ED20074BFD5 /* FlutterEngineManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterEngineManager.swift; sourceTree = "<group>"; };
 		B9DEC5562F1BF4AC0085FEC5 /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
@@ -300,6 +304,7 @@
 			isa = PBXGroup;
 			children = (
 				B9C191C92EFFF4C500AFE3C3 /* BalanceView.swift */,
+				B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */,
 			);
 			path = TopHome;
 			sourceTree = "<group>";
@@ -522,6 +527,7 @@
 				B9B00CD02E518DED00BCB306 /* imitateApp.swift in Sources */,
 				B95E7F5E2F8558C10071D91A /* HistoryInfoMapper.swift in Sources */,
 				B9C191CA2EFFF4C500AFE3C3 /* BalanceView.swift in Sources */,
+				B9C191D12F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */,
 				B96CBAAF2E51BF7800DB2E48 /* SceneDelegate.swift in Sources */,
 				B9E0D79A2F85344B00CF247C /* DictionaryExtension.swift in Sources */,
 				B961A2652F097AEB00B2989C /* InputBalanceSegmentView.swift in Sources */,
@@ -559,6 +565,7 @@
 				B95E7F5C2F8558C10071D91A /* HistoryHomeViewModel.swift in Sources */,
 				B9C191C22EFFDE4E00AFE3C3 /* HistoryHomeView.swift in Sources */,
 				B9C191CB2EFFF4C500AFE3C3 /* BalanceView.swift in Sources */,
+				B9C191D22F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -590,6 +597,7 @@
 				B9C166642F267E7600A3BEC5 /* BalanceRecordInfo.swift in Sources */,
 				B95E7F5D2F8558C10071D91A /* HistoryHomeViewModel.swift in Sources */,
 				B9C191CC2EFFF4C500AFE3C3 /* BalanceView.swift in Sources */,
+				B9C191D32F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
@@ -37,18 +37,8 @@ struct BalanceGraphView: View {
         yTickInterval * Double(yDivisions)
     }
 
-    private var mondays: [Date] {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.locale = Locale(identifier: "ja_JP")
-        var components = DateComponents(year: year, month: month, day: 1)
-        guard let firstDay = calendar.date(from: components),
-              let range = calendar.range(of: .day, in: .month, for: firstDay) else { return [] }
-
-        return range.compactMap { day -> Date? in
-            components.day = day
-            guard let date = calendar.date(from: components) else { return nil }
-            return calendar.component(.weekday, from: date) == 2 ? date : nil
-        }
+    private var labelDays: [Int] {
+        [1, 5, 10, 15, 20, 25, daysInMonth]
     }
 
     private var daysInMonth: Int {
@@ -147,8 +137,7 @@ struct BalanceGraphView: View {
 
     private func xAxisLabels(plotWidth: CGFloat) -> some View {
         ZStack(alignment: .topLeading) {
-            ForEach(mondays, id: \.self) { monday in
-                let day = Calendar.current.component(.day, from: monday)
+            ForEach(labelDays, id: \.self) { day in
                 Text("\(month)/\(day)")
                     .font(.caption2)
                     .foregroundColor(.secondary)

--- a/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Charts
 
 struct DailyBalance {
     let date: Date
@@ -27,9 +28,11 @@ struct BalanceGraphHeaderView: View {
                     .font(.headline)
             }
             Spacer()
-            Text("\(String(year))年\(String(month))月")
-                .font(.headline)
-                .fontWeight(.semibold)
+            Button(action: {}) {
+                Text("\(String(year))年\(String(month))月")
+                    .font(.headline)
+                    .fontWeight(.semibold)
+            }
             Spacer()
             Button(action: {}) {
                 Image(systemName: "chevron.right")
@@ -49,22 +52,6 @@ struct BalanceGraphChartView: View {
     let dailyBalances: [DailyBalance]
 
     private let graphHeight: CGFloat = 220
-    private let xAxisHeight: CGFloat = 24
-    private let yDivisions: Int = 5
-
-    private var maxValue: Double {
-        let maxIncome = dailyBalances.map { $0.cumulativeIncome }.max() ?? 0
-        let maxExpenses = dailyBalances.map { $0.cumulativeExpenses }.max() ?? 0
-        return max(maxIncome, maxExpenses, 1)
-    }
-
-    private var yTickInterval: Double {
-        (maxValue / Double(yDivisions)).rounded(.up)
-    }
-
-    private var yAxisMax: Double {
-        yTickInterval * Double(yDivisions)
-    }
 
     private var labelDays: [Int] {
         [1, 5, 10, 15, 20, 25, daysInMonth]
@@ -80,95 +67,62 @@ struct BalanceGraphChartView: View {
     }
 
     var body: some View {
-        GeometryReader { geo in
-            let plotWidth = geo.size.width
-            ZStack(alignment: .topLeading) {
-                gridLines(plotWidth: plotWidth)
-                incomeLine(plotWidth: plotWidth)
-                expensesLine(plotWidth: plotWidth)
-                lastDayLabels(plotWidth: plotWidth)
-                xAxisLabels(plotWidth: plotWidth)
+        Chart {
+            ForEach(Array(dailyBalances.enumerated()), id: \.offset) { index, balance in
+                LineMark(
+                    x: .value("日付", index + 1),
+                    y: .value("金額", balance.cumulativeIncome),
+                    series: .value("種別", "収入")
+                )
+                .foregroundStyle(.blue)
+
+                LineMark(
+                    x: .value("日付", index + 1),
+                    y: .value("金額", balance.cumulativeExpenses),
+                    series: .value("種別", "支出")
+                )
+                .foregroundStyle(.red)
             }
-        }
-        .frame(height: graphHeight + xAxisHeight)
-    }
 
-    private func gridLines(plotWidth: CGFloat) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            ForEach((0...yDivisions).reversed(), id: \.self) { _ in
-                Rectangle()
-                    .fill(Color.secondary.opacity(0.2))
-                    .frame(width: plotWidth, height: 0.5)
-                    .frame(height: graphHeight / CGFloat(yDivisions))
-            }
-        }
-    }
+            if let last = dailyBalances.last {
+                PointMark(
+                    x: .value("日付", dailyBalances.count),
+                    y: .value("金額", last.cumulativeIncome)
+                )
+                .foregroundStyle(.clear)
+                .annotation(position: .topLeading) {
+                    Text(formatAmount(last.cumulativeIncome))
+                        .font(.caption2)
+                        .foregroundColor(.blue)
+                }
 
-    private func incomeLine(plotWidth: CGFloat) -> some View {
-        linePath(values: dailyBalances.map { $0.cumulativeIncome }, plotWidth: plotWidth)
-            .stroke(Color.blue, lineWidth: 2)
-    }
-
-    private func expensesLine(plotWidth: CGFloat) -> some View {
-        linePath(values: dailyBalances.map { $0.cumulativeExpenses }, plotWidth: plotWidth)
-            .stroke(Color.red, lineWidth: 2)
-    }
-
-    private func linePath(values: [Double], plotWidth: CGFloat) -> Path {
-        guard !values.isEmpty else { return Path() }
-        return Path { path in
-            for (index, value) in values.enumerated() {
-                let x = xPosition(day: index + 1, plotWidth: plotWidth)
-                let y = yPosition(value: value)
-                if index == 0 {
-                    path.move(to: CGPoint(x: x, y: y))
-                } else {
-                    path.addLine(to: CGPoint(x: x, y: y))
+                PointMark(
+                    x: .value("日付", dailyBalances.count),
+                    y: .value("金額", last.cumulativeExpenses)
+                )
+                .foregroundStyle(.clear)
+                .annotation(position: .topLeading) {
+                    Text(formatAmount(last.cumulativeExpenses))
+                        .font(.caption2)
+                        .foregroundColor(.red)
                 }
             }
         }
-    }
-
-    private func lastDayLabels(plotWidth: CGFloat) -> some View {
-        let lastIncome = dailyBalances.last?.cumulativeIncome ?? 0
-        let lastExpenses = dailyBalances.last?.cumulativeExpenses ?? 0
-        let x = xPosition(day: daysInMonth, plotWidth: plotWidth)
-
-        return ZStack(alignment: .topLeading) {
-            Text(formatAmount(lastIncome))
-                .font(.caption2)
-                .foregroundColor(.blue)
-                .offset(x: x - 30, y: yPosition(value: lastIncome) - 16)
-            Text(formatAmount(lastExpenses))
-                .font(.caption2)
-                .foregroundColor(.red)
-                .offset(x: x - 30, y: yPosition(value: lastExpenses) - 16)
-        }
-    }
-
-    private func xAxisLabels(plotWidth: CGFloat) -> some View {
-        ZStack(alignment: .topLeading) {
-            ForEach(labelDays, id: \.self) { day in
-                Text("\(month)/\(day)")
-                    .font(.caption2)
-                    .foregroundColor(.secondary)
-                    .offset(
-                        x: xPosition(day: day, plotWidth: plotWidth) - 10,
-                        y: graphHeight + 4
-                    )
+        .chartXScale(domain: 1...daysInMonth)
+        .chartXAxis {
+            AxisMarks(values: labelDays) { value in
+                AxisGridLine()
+                AxisValueLabel {
+                    if let day = value.as(Int.self) {
+                        Text("\(month)/\(day)")
+                            .font(.caption2)
+                    }
+                }
             }
         }
-        .frame(width: plotWidth, height: graphHeight + xAxisHeight, alignment: .topLeading)
-    }
-
-    private func xPosition(day: Int, plotWidth: CGFloat) -> CGFloat {
-        let ratio = CGFloat(day - 1) / CGFloat(max(daysInMonth - 1, 1))
-        return ratio * plotWidth
-    }
-
-    private func yPosition(value: Double) -> CGFloat {
-        let ratio = CGFloat(value / yAxisMax)
-        return graphHeight * (1 - ratio)
+        .chartYAxis(.hidden)
+        .chartLegend(.hidden)
+        .frame(height: graphHeight)
     }
 
     private func formatAmount(_ value: Double) -> String {
@@ -190,6 +144,7 @@ struct BalanceGraphView: View {
         VStack(alignment: .leading, spacing: 0) {
             BalanceGraphHeaderView(year: year, month: month)
             BalanceGraphChartView(year: year, month: month, dailyBalances: dailyBalances)
+                .padding(.horizontal, 4)
         }
         .padding(.horizontal)
     }

--- a/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
@@ -1,0 +1,195 @@
+//
+//  BalanceGraphView.swift
+//  imitate
+//
+//  Created by garigari0118 on 2026/04/18.
+//
+
+import SwiftUI
+
+struct DailyBalance {
+    let date: Date
+    let cumulativeIncome: Double
+    let cumulativeExpenses: Double
+}
+
+struct BalanceGraphView: View {
+
+    let year: Int
+    let month: Int
+    let dailyBalances: [DailyBalance]
+
+    private let graphHeight: CGFloat = 220
+    private let yAxisWidth: CGFloat = 64
+    private let xAxisHeight: CGFloat = 24
+    private let yDivisions: Int = 5
+
+    private var maxValue: Double {
+        let maxIncome = dailyBalances.map { $0.cumulativeIncome }.max() ?? 0
+        let maxExpenses = dailyBalances.map { $0.cumulativeExpenses }.max() ?? 0
+        return max(maxIncome, maxExpenses, 1)
+    }
+
+    private var yTickInterval: Double {
+        (maxValue / Double(yDivisions)).rounded(.up)
+    }
+
+    private var yAxisMax: Double {
+        yTickInterval * Double(yDivisions)
+    }
+
+    private var mondays: [Date] {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "ja_JP")
+        var components = DateComponents(year: year, month: month, day: 1)
+        guard let firstDay = calendar.date(from: components),
+              let range = calendar.range(of: .day, in: .month, for: firstDay) else { return [] }
+
+        return range.compactMap { day -> Date? in
+            components.day = day
+            guard let date = calendar.date(from: components) else { return nil }
+            return calendar.component(.weekday, from: date) == 2 ? date : nil
+        }
+    }
+
+    private var daysInMonth: Int {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "ja_JP")
+        let components = DateComponents(year: year, month: month, day: 1)
+        guard let firstDay = calendar.date(from: components),
+              let range = calendar.range(of: .day, in: .month, for: firstDay) else { return 30 }
+        return range.count
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            monthHeader
+            graphArea
+        }
+        .padding(.horizontal)
+    }
+
+    private var monthHeader: some View {
+        HStack {
+            Text("\(year)年\(month)月")
+                .font(.headline)
+                .fontWeight(.semibold)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 8)
+    }
+
+    private var graphArea: some View {
+        HStack(alignment: .top, spacing: 0) {
+            yAxisLabels
+            GeometryReader { geo in
+                let plotWidth = geo.size.width
+                ZStack(alignment: .topLeading) {
+                    gridLines(plotWidth: plotWidth)
+                    incomeLine(plotWidth: plotWidth)
+                    expensesLine(plotWidth: plotWidth)
+                    xAxisLabels(plotWidth: plotWidth)
+                }
+            }
+            .frame(height: graphHeight + xAxisHeight)
+        }
+    }
+
+    private var yAxisLabels: some View {
+        VStack(alignment: .trailing, spacing: 0) {
+            ForEach((0...yDivisions).reversed(), id: \.self) { i in
+                let value = yTickInterval * Double(i)
+                Text(formatAmount(value))
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .frame(height: graphHeight / CGFloat(yDivisions))
+                    .frame(width: yAxisWidth, alignment: .trailing)
+            }
+            Spacer().frame(height: xAxisHeight)
+        }
+    }
+
+    private func gridLines(plotWidth: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach((0...yDivisions).reversed(), id: \.self) { _ in
+                Rectangle()
+                    .fill(Color.secondary.opacity(0.2))
+                    .frame(width: plotWidth, height: 0.5)
+                    .frame(height: graphHeight / CGFloat(yDivisions))
+            }
+        }
+    }
+
+    private func incomeLine(plotWidth: CGFloat) -> some View {
+        linePath(values: dailyBalances.map { $0.cumulativeIncome }, plotWidth: plotWidth)
+            .stroke(Color.blue, lineWidth: 2)
+    }
+
+    private func expensesLine(plotWidth: CGFloat) -> some View {
+        linePath(values: dailyBalances.map { $0.cumulativeExpenses }, plotWidth: plotWidth)
+            .stroke(Color.red, lineWidth: 2)
+    }
+
+    private func linePath(values: [Double], plotWidth: CGFloat) -> Path {
+        guard !values.isEmpty else { return Path() }
+        return Path { path in
+            for (index, value) in values.enumerated() {
+                let x = xPosition(day: index + 1, plotWidth: plotWidth)
+                let y = yPosition(value: value)
+                if index == 0 {
+                    path.move(to: CGPoint(x: x, y: y))
+                } else {
+                    path.addLine(to: CGPoint(x: x, y: y))
+                }
+            }
+        }
+    }
+
+    private func xAxisLabels(plotWidth: CGFloat) -> some View {
+        ZStack(alignment: .topLeading) {
+            ForEach(mondays, id: \.self) { monday in
+                let day = Calendar.current.component(.day, from: monday)
+                Text("\(day)")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .offset(
+                        x: xPosition(day: day, plotWidth: plotWidth) - 8,
+                        y: graphHeight + 4
+                    )
+            }
+        }
+        .frame(width: plotWidth, height: graphHeight + xAxisHeight, alignment: .topLeading)
+    }
+
+    private func xPosition(day: Int, plotWidth: CGFloat) -> CGFloat {
+        let ratio = CGFloat(day - 1) / CGFloat(max(daysInMonth - 1, 1))
+        return ratio * plotWidth
+    }
+
+    private func yPosition(value: Double) -> CGFloat {
+        let ratio = CGFloat(value / yAxisMax)
+        return graphHeight * (1 - ratio)
+    }
+
+    private func formatAmount(_ value: Double) -> String {
+        if value >= 10_000 {
+            return String(format: "%.0f万", value / 10_000)
+        }
+        return String(format: "%.0f", value)
+    }
+}
+
+#Preview {
+    let calendar = Calendar.current
+    let today = Date()
+    let dummies: [DailyBalance] = (1...30).map { day in
+        var components = DateComponents(year: 2026, month: 4, day: day)
+        let date = calendar.date(from: components) ?? today
+        return DailyBalance(
+            date: date,
+            cumulativeIncome: Double(day) * 1_500,
+            cumulativeExpenses: Double(day) * 900
+        )
+    }
+    BalanceGraphView(year: 2026, month: 4, dailyBalances: dummies)
+}

--- a/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
@@ -71,7 +71,7 @@ struct BalanceGraphView: View {
 
     private var monthHeader: some View {
         HStack {
-            Text("\(year)年\(month)月")
+            Text("\(String(year))年\(String(month))月")
                 .font(.headline)
                 .fontWeight(.semibold)
         }

--- a/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
@@ -149,11 +149,11 @@ struct BalanceGraphView: View {
         ZStack(alignment: .topLeading) {
             ForEach(mondays, id: \.self) { monday in
                 let day = Calendar.current.component(.day, from: monday)
-                Text("\(day)")
+                Text("\(month)/\(day)")
                     .font(.caption2)
                     .foregroundColor(.secondary)
                     .offset(
-                        x: xPosition(day: day, plotWidth: plotWidth) - 8,
+                        x: xPosition(day: day, plotWidth: plotWidth) - 10,
                         y: graphHeight + 4
                     )
             }

--- a/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
@@ -177,19 +177,23 @@ struct BalanceGraphView: View {
         }
         return String(format: "%.0f", value)
     }
+
+    static var dummyPreview: BalanceGraphView {
+        let calendar = Calendar.current
+        let today = Date()
+        let dummies: [DailyBalance] = (1...30).map { day in
+            let components = DateComponents(year: 2026, month: 4, day: day)
+            let date = calendar.date(from: components) ?? today
+            return DailyBalance(
+                date: date,
+                cumulativeIncome: Double(day) * 1_500,
+                cumulativeExpenses: Double(day) * 900
+            )
+        }
+        return BalanceGraphView(year: 2026, month: 4, dailyBalances: dummies)
+    }
 }
 
 #Preview {
-    let calendar = Calendar.current
-    let today = Date()
-    let dummies: [DailyBalance] = (1...30).map { day in
-        var components = DateComponents(year: 2026, month: 4, day: day)
-        let date = calendar.date(from: components) ?? today
-        return DailyBalance(
-            date: date,
-            cumulativeIncome: Double(day) * 1_500,
-            cumulativeExpenses: Double(day) * 900
-        )
-    }
-    BalanceGraphView(year: 2026, month: 4, dailyBalances: dummies)
+    BalanceGraphView.dummyPreview
 }

--- a/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
@@ -20,7 +20,6 @@ struct BalanceGraphView: View {
     let dailyBalances: [DailyBalance]
 
     private let graphHeight: CGFloat = 220
-    private let yAxisWidth: CGFloat = 64
     private let xAxisHeight: CGFloat = 24
     private let yDivisions: Int = 5
 
@@ -80,33 +79,17 @@ struct BalanceGraphView: View {
     }
 
     private var graphArea: some View {
-        HStack(alignment: .top, spacing: 0) {
-            yAxisLabels
-            GeometryReader { geo in
-                let plotWidth = geo.size.width
-                ZStack(alignment: .topLeading) {
-                    gridLines(plotWidth: plotWidth)
-                    incomeLine(plotWidth: plotWidth)
-                    expensesLine(plotWidth: plotWidth)
-                    xAxisLabels(plotWidth: plotWidth)
-                }
+        GeometryReader { geo in
+            let plotWidth = geo.size.width
+            ZStack(alignment: .topLeading) {
+                gridLines(plotWidth: plotWidth)
+                incomeLine(plotWidth: plotWidth)
+                expensesLine(plotWidth: plotWidth)
+                lastDayLabels(plotWidth: plotWidth)
+                xAxisLabels(plotWidth: plotWidth)
             }
-            .frame(height: graphHeight + xAxisHeight)
         }
-    }
-
-    private var yAxisLabels: some View {
-        VStack(alignment: .trailing, spacing: 0) {
-            ForEach((0...yDivisions).reversed(), id: \.self) { i in
-                let value = yTickInterval * Double(i)
-                Text(formatAmount(value))
-                    .font(.caption2)
-                    .foregroundColor(.secondary)
-                    .frame(height: graphHeight / CGFloat(yDivisions))
-                    .frame(width: yAxisWidth, alignment: .trailing)
-            }
-            Spacer().frame(height: xAxisHeight)
-        }
+        .frame(height: graphHeight + xAxisHeight)
     }
 
     private func gridLines(plotWidth: CGFloat) -> some View {
@@ -145,6 +128,23 @@ struct BalanceGraphView: View {
         }
     }
 
+    private func lastDayLabels(plotWidth: CGFloat) -> some View {
+        let lastIncome = dailyBalances.last?.cumulativeIncome ?? 0
+        let lastExpenses = dailyBalances.last?.cumulativeExpenses ?? 0
+        let x = xPosition(day: daysInMonth, plotWidth: plotWidth)
+
+        return ZStack(alignment: .topLeading) {
+            Text(formatAmount(lastIncome))
+                .font(.caption2)
+                .foregroundColor(.blue)
+                .offset(x: x - 30, y: yPosition(value: lastIncome) - 16)
+            Text(formatAmount(lastExpenses))
+                .font(.caption2)
+                .foregroundColor(.red)
+                .offset(x: x - 30, y: yPosition(value: lastExpenses) - 16)
+        }
+    }
+
     private func xAxisLabels(plotWidth: CGFloat) -> some View {
         ZStack(alignment: .topLeading) {
             ForEach(mondays, id: \.self) { monday in
@@ -172,10 +172,9 @@ struct BalanceGraphView: View {
     }
 
     private func formatAmount(_ value: Double) -> String {
-        if value >= 10_000 {
-            return String(format: "%.0f万", value / 10_000)
-        }
-        return String(format: "%.0f", value)
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter.string(from: NSNumber(value: value)) ?? "\(Int(value))"
     }
 
     static var dummyPreview: BalanceGraphView {

--- a/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
@@ -13,7 +13,36 @@ struct DailyBalance {
     let cumulativeExpenses: Double
 }
 
-struct BalanceGraphView: View {
+// MARK: - ① Header
+
+struct BalanceGraphHeaderView: View {
+
+    let year: Int
+    let month: Int
+
+    var body: some View {
+        HStack {
+            Button(action: {}) {
+                Image(systemName: "chevron.left")
+                    .font(.headline)
+            }
+            Spacer()
+            Text("\(String(year))年\(String(month))月")
+                .font(.headline)
+                .fontWeight(.semibold)
+            Spacer()
+            Button(action: {}) {
+                Image(systemName: "chevron.right")
+                    .font(.headline)
+            }
+        }
+        .padding(.bottom, 8)
+    }
+}
+
+// MARK: - ② Chart
+
+struct BalanceGraphChartView: View {
 
     let year: Int
     let month: Int
@@ -51,24 +80,6 @@ struct BalanceGraphView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            monthHeader
-            graphArea
-        }
-        .padding(.horizontal)
-    }
-
-    private var monthHeader: some View {
-        HStack {
-            Text("\(String(year))年\(String(month))月")
-                .font(.headline)
-                .fontWeight(.semibold)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.bottom, 8)
-    }
-
-    private var graphArea: some View {
         GeometryReader { geo in
             let plotWidth = geo.size.width
             ZStack(alignment: .topLeading) {
@@ -164,6 +175,23 @@ struct BalanceGraphView: View {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         return formatter.string(from: NSNumber(value: value)) ?? "\(Int(value))"
+    }
+}
+
+// MARK: - ③ Container
+
+struct BalanceGraphView: View {
+
+    let year: Int
+    let month: Int
+    let dailyBalances: [DailyBalance]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            BalanceGraphHeaderView(year: year, month: month)
+            BalanceGraphChartView(year: year, month: month, dailyBalances: dailyBalances)
+        }
+        .padding(.horizontal)
     }
 
     static var dummyPreview: BalanceGraphView {

--- a/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
@@ -18,6 +18,8 @@ struct TopHomeView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     BalanceView(type: .income, balance: viewModel.monthlyIncome)
                     BalanceView(type: .expenses, balance: viewModel.monthlyExpenses)
+                    BalanceGraphView.dummyPreview
+                        .padding(.vertical, 8)
                 }
             }
             

--- a/project/iOS/imitateTests/HistoryHomeViewModelTests.swift
+++ b/project/iOS/imitateTests/HistoryHomeViewModelTests.swift
@@ -179,6 +179,14 @@ final class HistoryHomeViewModelTests: XCTestCase {
 
 /// テスト用のモック BalanceRecordRepository
 class MockBalanceRecordRepository: BalanceRecordRepositoryProtocol {
+    func getMonthlyIncome(onSuccess: @escaping ((Int) -> Void), onFailure: @escaping (() -> Void)) {
+        // TODO: 別途テスト作成
+    }
+    
+    func getMonthlyExpenses(onSuccess: @escaping ((Int) -> Void), onFailure: @escaping (() -> Void)) {
+        // TODO: 別途テスト作成
+    }
+    
 
     var mockRecords: [[String: Any]]? = []
     var shouldSucceed: Bool = true


### PR DESCRIPTION
## Summary
- 収入・支出の月別累計グラフを表示する `BalanceGraphView` を新規作成
- Swift Charts を使用した折れ線グラフ（収入=青、支出=赤）
- ヘッダーに年月表示と `<` `>` ボタン（月切り替えは今後実装）
- 横軸ラベルに 1・5・10・15・20・25・月末の日付を `m/d` 形式で表示
- 最終日の累計金額をグラフ内にインライン表示
- `TopHomeView` の `BalanceView` 下部に組み込み済み（現在はダミーデータ）

## Test plan
- [ ] Xcodeでビルドが通ること
- [ ] TopHomeViewでグラフが表示されること
- [ ] 収入線（青）・支出線（赤）が正しく描画されること
- [ ] 横軸ラベルが正しく表示されること
- [ ] 最終日の金額ラベルがグラフ内に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)