### PR TITLE
【Flutter/iOS】グラフデータのFlutter-iOS連携・月切り替え機能の実装

### DIFF
--- a/project/Flutter/lib/BalanceRecordRepository.dart
+++ b/project/Flutter/lib/BalanceRecordRepository.dart
@@ -41,6 +41,10 @@ class BalanceRecordRepository {
           final dailyData = await getDailyBalanceData(year, month);
           print('dart getDailyBalanceData result: $dailyData');
           return dailyData;
+        case 'getAvailableYearMonths':
+          final yearMonths = await getAvailableYearMonths();
+          print('dart getAvailableYearMonths result: $yearMonths');
+          return yearMonths;
         default:
           throw PlatformException(code: 'Unimplemented');
       }
@@ -165,6 +169,15 @@ class BalanceRecordRepository {
     }
 
     return result;
+  }
+
+  Future<List<String>> getAvailableYearMonths() async {
+    print('getAvailableYearMonths');
+    final db = await database;
+    final result = await db.rawQuery(
+      'SELECT DISTINCT substr(date, 1, 7) as yearMonth FROM balanceRecords ORDER BY yearMonth ASC',
+    );
+    return result.map((row) => row['yearMonth'] as String).toList();
   }
 
   Future<int> getMonthlyExpenses() async {

--- a/project/Flutter/lib/BalanceRecordRepository.dart
+++ b/project/Flutter/lib/BalanceRecordRepository.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
+import 'package:intl/intl.dart';
 
 class BalanceRecordRepository {
   static const platform = MethodChannel('BalanceRecordRepository');
@@ -107,7 +108,7 @@ class BalanceRecordRepository {
     print('getMonthlyIncome');
     final db = await database;
     final now = DateTime.now();
-    final currentMonth = '${now.year}-${now.month.toString().padLeft(2, '0')}';
+    final currentMonth = DateFormat('yyyy-MM').format(now);
 
     final records = await db.query(
       'balanceRecords',
@@ -127,7 +128,7 @@ class BalanceRecordRepository {
   Future<List<Map<String, dynamic>>> getDailyBalanceData(int year, int month) async {
     print('getDailyBalanceData: $year-$month');
     final db = await database;
-    final monthStr = '$year-${month.toString().padLeft(2, '0')}';
+    final monthStr = DateFormat('yyyy-MM').format(DateTime(year, month));
 
     final records = await db.query(
       'balanceRecords',
@@ -143,7 +144,7 @@ class BalanceRecordRepository {
     final List<Map<String, dynamic>> result = [];
 
     for (int day = 1; day <= daysInMonth; day++) {
-      final dayStr = '$monthStr-${day.toString().padLeft(2, '0')}';
+      final dayStr = DateFormat('yyyy-MM-dd').format(DateTime(year, month, day));
 
       for (var record in records) {
         if (record['date'] == dayStr) {
@@ -170,7 +171,7 @@ class BalanceRecordRepository {
     print('getMonthlyExpenses');
     final db = await database;
     final now = DateTime.now();
-    final currentMonth = '${now.year}-${now.month.toString().padLeft(2, '0')}';
+    final currentMonth = DateFormat('yyyy-MM').format(now);
 
     final records = await db.query(
       'balanceRecords',

--- a/project/Flutter/lib/BalanceRecordRepository.dart
+++ b/project/Flutter/lib/BalanceRecordRepository.dart
@@ -33,6 +33,13 @@ class BalanceRecordRepository {
           final expenses = await getMonthlyExpenses();
           print('dart getMonthlyExpenses result: $expenses');
           return expenses;
+        case 'getDailyBalanceData':
+          final args = Map<String, dynamic>.from(call.arguments);
+          final year = args['year'] as int;
+          final month = args['month'] as int;
+          final dailyData = await getDailyBalanceData(year, month);
+          print('dart getDailyBalanceData result: $dailyData');
+          return dailyData;
         default:
           throw PlatformException(code: 'Unimplemented');
       }
@@ -115,6 +122,48 @@ class BalanceRecordRepository {
     }
 
     return total;
+  }
+
+  Future<List<Map<String, dynamic>>> getDailyBalanceData(int year, int month) async {
+    print('getDailyBalanceData: $year-$month');
+    final db = await database;
+    final monthStr = '$year-${month.toString().padLeft(2, '0')}';
+
+    final records = await db.query(
+      'balanceRecords',
+      where: 'date LIKE ?',
+      whereArgs: ['$monthStr%'],
+      orderBy: 'date ASC',
+    );
+
+    final daysInMonth = DateTime(year, month + 1, 0).day;
+    int cumulativeIncome = 0;
+    int cumulativeExpenses = 0;
+
+    final List<Map<String, dynamic>> result = [];
+
+    for (int day = 1; day <= daysInMonth; day++) {
+      final dayStr = '$monthStr-${day.toString().padLeft(2, '0')}';
+
+      for (var record in records) {
+        if (record['date'] == dayStr) {
+          final amount = record['amount'] as int? ?? 0;
+          if (record['type'] == '収入') {
+            cumulativeIncome += amount;
+          } else if (record['type'] == '支出') {
+            cumulativeExpenses += amount;
+          }
+        }
+      }
+
+      result.add({
+        'date': dayStr,
+        'cumulativeIncome': cumulativeIncome,
+        'cumulativeExpenses': cumulativeExpenses,
+      });
+    }
+
+    return result;
   }
 
   Future<int> getMonthlyExpenses() async {

--- a/project/Flutter/pubspec.yaml
+++ b/project/Flutter/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   sqflite: ^2.4.2
   path: ^1.8.0
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:

--- a/project/iOS/imitate/Extension/DateExtension.swift
+++ b/project/iOS/imitate/Extension/DateExtension.swift
@@ -12,10 +12,19 @@ extension Date {
     enum DateFormatStyle: String {
        case yyyy_MM_dd = "yyyy-MM-dd"
     }
-    
+
     func toString(style: DateFormatStyle) -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = style.rawValue
         return formatter.string(from: self)
     }
+}
+
+extension DateFormatter {
+    static let yyyyMMdd: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }()
 }

--- a/project/iOS/imitate/Model/Repository/BalanceRecordRepository.swift
+++ b/project/iOS/imitate/Model/Repository/BalanceRecordRepository.swift
@@ -15,6 +15,9 @@ protocol BalanceRecordRepositoryProtocol {
                           onFailure: @escaping (() -> Void))
     func getMonthlyExpenses(onSuccess: @escaping ((Int) -> Void),
                             onFailure: @escaping (() -> Void))
+    func getDailyBalanceData(year: Int, month: Int,
+                             onSuccess: @escaping (([[String: Any]]) -> Void),
+                             onFailure: @escaping (() -> Void))
 }
 
 class BalanceRecordRepository: BalanceRecordRepositoryProtocol {
@@ -71,6 +74,24 @@ class BalanceRecordRepository: BalanceRecordRepositoryProtocol {
                 onFailure()
             } else {
                 print("failed getMonthlyExpenses")
+                onFailure()
+            }
+        }
+    }
+
+    func getDailyBalanceData(year: Int, month: Int,
+                             onSuccess: @escaping (([[String: Any]]) -> Void),
+                             onFailure: @escaping (() -> Void)) {
+        let arguments: [String: Any] = ["year": year, "month": month]
+        FlutterEngineManager.shared.channel?.invokeMethod("getDailyBalanceData", arguments: arguments) { result in
+
+            if let data = result as? [[String: Any]] {
+                onSuccess(data)
+            } else if let error = result as? FlutterError {
+                print("Error: \(error.message ?? "Unknown error")")
+                onFailure()
+            } else {
+                print("failed getDailyBalanceData")
                 onFailure()
             }
         }

--- a/project/iOS/imitate/Model/Repository/BalanceRecordRepository.swift
+++ b/project/iOS/imitate/Model/Repository/BalanceRecordRepository.swift
@@ -18,6 +18,8 @@ protocol BalanceRecordRepositoryProtocol {
     func getDailyBalanceData(year: Int, month: Int,
                              onSuccess: @escaping (([[String: Any]]) -> Void),
                              onFailure: @escaping (() -> Void))
+    func getAvailableYearMonths(onSuccess: @escaping (([String]) -> Void),
+                                onFailure: @escaping (() -> Void))
 }
 
 class BalanceRecordRepository: BalanceRecordRepositoryProtocol {
@@ -92,6 +94,22 @@ class BalanceRecordRepository: BalanceRecordRepositoryProtocol {
                 onFailure()
             } else {
                 print("failed getDailyBalanceData")
+                onFailure()
+            }
+        }
+    }
+
+    func getAvailableYearMonths(onSuccess: @escaping (([String]) -> Void),
+                                onFailure: @escaping (() -> Void)) {
+        FlutterEngineManager.shared.channel?.invokeMethod("getAvailableYearMonths", arguments: nil) { result in
+
+            if let yearMonths = result as? [String] {
+                onSuccess(yearMonths)
+            } else if let error = result as? FlutterError {
+                print("Error: \(error.message ?? "Unknown error")")
+                onFailure()
+            } else {
+                print("failed getAvailableYearMonths")
                 onFailure()
             }
         }

--- a/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
@@ -14,87 +14,137 @@ struct DailyBalance {
     let cumulativeExpenses: Double
 }
 
-// MARK: - ① Header
+// MARK: - BalanceGraphView
+
+struct BalanceGraphView: View {
+
+    enum BalanceGraphState {
+        case empty
+        case hasData(yearMonths: [(year: Int, month: Int)], balances: [DailyBalance])
+    }
+
+    let year: Int
+    let month: Int
+    let dailyBalances: [DailyBalance]
+    var onPreviousMonth: (() -> Void)? = nil
+    var onNextMonth: (() -> Void)? = nil
+    var onSelectYearMonth: ((Int, Int) -> Void)? = nil
+    var availableYearMonths: [(year: Int, month: Int)] = []
+
+    private var state: BalanceGraphState {
+        availableYearMonths.isEmpty
+            ? .empty
+            : .hasData(yearMonths: availableYearMonths, balances: dailyBalances)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            BalanceGraphHeaderView(
+                year: year,
+                month: month,
+                state: state,
+                onPreviousMonth: onPreviousMonth,
+                onNextMonth: onNextMonth,
+                onSelectYearMonth: onSelectYearMonth
+            )
+            BalanceGraphChartView(year: year, month: month, state: state)
+                .padding(.horizontal, 4)
+        }
+        .padding(.horizontal)
+    }
+
+    static var dummyPreview: BalanceGraphView {
+        let calendar = Calendar.current
+        let today = Date()
+        let dummies: [DailyBalance] = (1...30).map { day in
+            let components = DateComponents(year: 2026, month: 4, day: day)
+            let date = calendar.date(from: components) ?? today
+            return DailyBalance(
+                date: date,
+                cumulativeIncome: Double(day) * 1_500,
+                cumulativeExpenses: Double(day) * 900
+            )
+        }
+        return BalanceGraphView(year: 2026, month: 4, dailyBalances: dummies)
+    }
+}
+
+// MARK: - BalanceGraphHeaderView
 
 struct BalanceGraphHeaderView: View {
 
     let year: Int
     let month: Int
+    let state: BalanceGraphView.BalanceGraphState
     var onPreviousMonth: (() -> Void)? = nil
     var onNextMonth: (() -> Void)? = nil
     var onSelectYearMonth: ((Int, Int) -> Void)? = nil
-    var availableYearMonths: [(year: Int, month: Int)] = []
 
     @State private var showingDatePicker = false
     @State private var selectedIndex: Int = 0
 
     var body: some View {
         HStack {
-            Button(action: { onPreviousMonth?() }) {
-                Image(systemName: "chevron.left")
-                    .font(.headline)
-            }
-            Spacer()
-            Button(action: {
-                selectedIndex = availableYearMonths.firstIndex(where: { $0.year == year && $0.month == month }) ?? 0
-                showingDatePicker = true
-            }) {
-                Text("\(String(year))年\(String(month))月")
-                    .font(.headline)
-                    .fontWeight(.semibold)
-            }
-            .disabled(availableYearMonths.isEmpty)
-            Spacer()
-            Button(action: { onNextMonth?() }) {
-                Image(systemName: "chevron.right")
-                    .font(.headline)
+            switch state {
+            case .empty:
+                EmptyView()
+            case .hasData(let yearMonths, _):
+                Button(action: { onPreviousMonth?() }) {
+                    Image(systemName: "chevron.left")
+                        .font(.headline)
+                }
+                Spacer()
+                Button(action: {
+                    selectedIndex = yearMonths.firstIndex(where: { $0.year == year && $0.month == month }) ?? 0
+                    showingDatePicker = true
+                }) {
+                    Text("\(String(year))年\(String(month))月")
+                        .font(.headline)
+                        .fontWeight(.semibold)
+                }
+                Spacer()
+                Button(action: { onNextMonth?() }) {
+                    Image(systemName: "chevron.right")
+                        .font(.headline)
+                }
+                .sheet(isPresented: $showingDatePicker) {
+                    VStack(spacing: 16) {
+                        Text("年月を選択")
+                            .font(.headline)
+                            .padding(.top, 24)
+
+                        Picker("年月", selection: $selectedIndex) {
+                            ForEach(yearMonths.indices, id: \.self) { index in
+                                let ym = yearMonths[index]
+                                Text("\(String(ym.year))年\(ym.month)月").tag(index)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+
+                        Button("完了") {
+                            guard selectedIndex < yearMonths.count else { return }
+                            let selected = yearMonths[selectedIndex]
+                            onSelectYearMonth?(selected.year, selected.month)
+                            showingDatePicker = false
+                        }
+                        .font(.headline)
+                        .padding(.bottom, 24)
+                    }
+                    .presentationDetents([.fraction(0.4)])
+                }
             }
         }
         .padding(.bottom, 8)
-        .sheet(isPresented: $showingDatePicker) {
-            VStack(spacing: 16) {
-                Text("年月を選択")
-                    .font(.headline)
-                    .padding(.top, 24)
-
-                Picker("年月", selection: $selectedIndex) {
-                    ForEach(availableYearMonths.indices, id: \.self) { index in
-                        let ym = availableYearMonths[index]
-                        Text("\(String(ym.year))年\(ym.month)月").tag(index)
-                    }
-                }
-                .pickerStyle(.wheel)
-
-                Button("完了") {
-                    guard selectedIndex < availableYearMonths.count else { return }
-                    let selected = availableYearMonths[selectedIndex]
-                    onSelectYearMonth?(selected.year, selected.month)
-                    showingDatePicker = false
-                }
-                .font(.headline)
-                .padding(.bottom, 24)
-            }
-            .presentationDetents([.fraction(0.4)])
-        }
     }
 }
 
-// MARK: - ② Chart
+// MARK: - BalanceGraphChartView
 
 struct BalanceGraphChartView: View {
 
-    enum GraphState {
-        case empty
-        case hasData([DailyBalance])
-    }
-
     let year: Int
     let month: Int
-    let dailyBalances: [DailyBalance]
-
-    private var graphState: GraphState {
-        dailyBalances.isEmpty ? .empty : .hasData(dailyBalances)
-    }
+    let state: BalanceGraphView.BalanceGraphState
 
     private let graphHeight: CGFloat = 220
 
@@ -112,7 +162,7 @@ struct BalanceGraphChartView: View {
     }
 
     var body: some View {
-        switch graphState {
+        switch state {
         case .empty:
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
@@ -122,7 +172,7 @@ struct BalanceGraphChartView: View {
                     .foregroundColor(.secondary)
             }
             .frame(height: graphHeight)
-        case .hasData(let balances):
+        case .hasData(_, let balances):
             Chart {
                 ForEach(Array(balances.enumerated()), id: \.offset) { index, balance in
                     LineMark(
@@ -186,50 +236,6 @@ struct BalanceGraphChartView: View {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         return formatter.string(from: NSNumber(value: value)) ?? "\(Int(value))"
-    }
-}
-
-// MARK: - ③ Container
-
-struct BalanceGraphView: View {
-
-    let year: Int
-    let month: Int
-    let dailyBalances: [DailyBalance]
-    var onPreviousMonth: (() -> Void)? = nil
-    var onNextMonth: (() -> Void)? = nil
-    var onSelectYearMonth: ((Int, Int) -> Void)? = nil
-    var availableYearMonths: [(year: Int, month: Int)] = []
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            BalanceGraphHeaderView(
-                year: year,
-                month: month,
-                onPreviousMonth: onPreviousMonth,
-                onNextMonth: onNextMonth,
-                onSelectYearMonth: onSelectYearMonth,
-                availableYearMonths: availableYearMonths
-            )
-            BalanceGraphChartView(year: year, month: month, dailyBalances: dailyBalances)
-                .padding(.horizontal, 4)
-        }
-        .padding(.horizontal)
-    }
-
-    static var dummyPreview: BalanceGraphView {
-        let calendar = Calendar.current
-        let today = Date()
-        let dummies: [DailyBalance] = (1...30).map { day in
-            let components = DateComponents(year: 2026, month: 4, day: day)
-            let date = calendar.date(from: components) ?? today
-            return DailyBalance(
-                date: date,
-                cumulativeIncome: Double(day) * 1_500,
-                cumulativeExpenses: Double(day) * 900
-            )
-        }
-        return BalanceGraphView(year: 2026, month: 4, dailyBalances: dummies)
     }
 }
 

--- a/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
@@ -20,10 +20,12 @@ struct BalanceGraphHeaderView: View {
 
     let year: Int
     let month: Int
+    var onPreviousMonth: (() -> Void)? = nil
+    var onNextMonth: (() -> Void)? = nil
 
     var body: some View {
         HStack {
-            Button(action: {}) {
+            Button(action: { onPreviousMonth?() }) {
                 Image(systemName: "chevron.left")
                     .font(.headline)
             }
@@ -34,7 +36,7 @@ struct BalanceGraphHeaderView: View {
                     .fontWeight(.semibold)
             }
             Spacer()
-            Button(action: {}) {
+            Button(action: { onNextMonth?() }) {
                 Image(systemName: "chevron.right")
                     .font(.headline)
             }
@@ -139,10 +141,17 @@ struct BalanceGraphView: View {
     let year: Int
     let month: Int
     let dailyBalances: [DailyBalance]
+    var onPreviousMonth: (() -> Void)? = nil
+    var onNextMonth: (() -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            BalanceGraphHeaderView(year: year, month: month)
+            BalanceGraphHeaderView(
+                year: year,
+                month: month,
+                onPreviousMonth: onPreviousMonth,
+                onNextMonth: onNextMonth
+            )
             BalanceGraphChartView(year: year, month: month, dailyBalances: dailyBalances)
                 .padding(.horizontal, 4)
         }

--- a/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
@@ -22,6 +22,11 @@ struct BalanceGraphHeaderView: View {
     let month: Int
     var onPreviousMonth: (() -> Void)? = nil
     var onNextMonth: (() -> Void)? = nil
+    var onSelectYearMonth: ((Int, Int) -> Void)? = nil
+    var availableYearMonths: [(year: Int, month: Int)] = []
+
+    @State private var showingDatePicker = false
+    @State private var selectedIndex: Int = 0
 
     var body: some View {
         HStack {
@@ -30,7 +35,10 @@ struct BalanceGraphHeaderView: View {
                     .font(.headline)
             }
             Spacer()
-            Button(action: {}) {
+            Button(action: {
+                selectedIndex = availableYearMonths.firstIndex(where: { $0.year == year && $0.month == month }) ?? 0
+                showingDatePicker = true
+            }) {
                 Text("\(String(year))年\(String(month))月")
                     .font(.headline)
                     .fontWeight(.semibold)
@@ -42,6 +50,30 @@ struct BalanceGraphHeaderView: View {
             }
         }
         .padding(.bottom, 8)
+        .sheet(isPresented: $showingDatePicker) {
+            VStack(spacing: 16) {
+                Text("年月を選択")
+                    .font(.headline)
+                    .padding(.top, 24)
+
+                Picker("年月", selection: $selectedIndex) {
+                    ForEach(availableYearMonths.indices, id: \.self) { index in
+                        let ym = availableYearMonths[index]
+                        Text("\(String(ym.year))年\(ym.month)月").tag(index)
+                    }
+                }
+                .pickerStyle(.wheel)
+
+                Button("完了") {
+                    let selected = availableYearMonths[selectedIndex]
+                    onSelectYearMonth?(selected.year, selected.month)
+                    showingDatePicker = false
+                }
+                .font(.headline)
+                .padding(.bottom, 24)
+            }
+            .presentationDetents([.fraction(0.4)])
+        }
     }
 }
 
@@ -143,6 +175,8 @@ struct BalanceGraphView: View {
     let dailyBalances: [DailyBalance]
     var onPreviousMonth: (() -> Void)? = nil
     var onNextMonth: (() -> Void)? = nil
+    var onSelectYearMonth: ((Int, Int) -> Void)? = nil
+    var availableYearMonths: [(year: Int, month: Int)] = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -150,7 +184,9 @@ struct BalanceGraphView: View {
                 year: year,
                 month: month,
                 onPreviousMonth: onPreviousMonth,
-                onNextMonth: onNextMonth
+                onNextMonth: onNextMonth,
+                onSelectYearMonth: onSelectYearMonth,
+                availableYearMonths: availableYearMonths
             )
             BalanceGraphChartView(year: year, month: month, dailyBalances: dailyBalances)
                 .padding(.horizontal, 4)

--- a/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHome/BalanceGraphView.swift
@@ -43,6 +43,7 @@ struct BalanceGraphHeaderView: View {
                     .font(.headline)
                     .fontWeight(.semibold)
             }
+            .disabled(availableYearMonths.isEmpty)
             Spacer()
             Button(action: { onNextMonth?() }) {
                 Image(systemName: "chevron.right")
@@ -65,6 +66,7 @@ struct BalanceGraphHeaderView: View {
                 .pickerStyle(.wheel)
 
                 Button("完了") {
+                    guard selectedIndex < availableYearMonths.count else { return }
                     let selected = availableYearMonths[selectedIndex]
                     onSelectYearMonth?(selected.year, selected.month)
                     showingDatePicker = false
@@ -81,9 +83,18 @@ struct BalanceGraphHeaderView: View {
 
 struct BalanceGraphChartView: View {
 
+    enum GraphState {
+        case empty
+        case hasData([DailyBalance])
+    }
+
     let year: Int
     let month: Int
     let dailyBalances: [DailyBalance]
+
+    private var graphState: GraphState {
+        dailyBalances.isEmpty ? .empty : .hasData(dailyBalances)
+    }
 
     private let graphHeight: CGFloat = 220
 
@@ -101,62 +112,74 @@ struct BalanceGraphChartView: View {
     }
 
     var body: some View {
-        Chart {
-            ForEach(Array(dailyBalances.enumerated()), id: \.offset) { index, balance in
-                LineMark(
-                    x: .value("日付", index + 1),
-                    y: .value("金額", balance.cumulativeIncome),
-                    series: .value("種別", "収入")
-                )
-                .foregroundStyle(.blue)
-
-                LineMark(
-                    x: .value("日付", index + 1),
-                    y: .value("金額", balance.cumulativeExpenses),
-                    series: .value("種別", "支出")
-                )
-                .foregroundStyle(.red)
+        switch graphState {
+        case .empty:
+            ZStack {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.secondary.opacity(0.1))
+                Text("データがありません")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
             }
+            .frame(height: graphHeight)
+        case .hasData(let balances):
+            Chart {
+                ForEach(Array(balances.enumerated()), id: \.offset) { index, balance in
+                    LineMark(
+                        x: .value("日付", index + 1),
+                        y: .value("金額", balance.cumulativeIncome),
+                        series: .value("種別", "収入")
+                    )
+                    .foregroundStyle(.blue)
 
-            if let last = dailyBalances.last {
-                PointMark(
-                    x: .value("日付", dailyBalances.count),
-                    y: .value("金額", last.cumulativeIncome)
-                )
-                .foregroundStyle(.clear)
-                .annotation(position: .topLeading) {
-                    Text(formatAmount(last.cumulativeIncome))
-                        .font(.caption2)
-                        .foregroundColor(.blue)
+                    LineMark(
+                        x: .value("日付", index + 1),
+                        y: .value("金額", balance.cumulativeExpenses),
+                        series: .value("種別", "支出")
+                    )
+                    .foregroundStyle(.red)
                 }
 
-                PointMark(
-                    x: .value("日付", dailyBalances.count),
-                    y: .value("金額", last.cumulativeExpenses)
-                )
-                .foregroundStyle(.clear)
-                .annotation(position: .topLeading) {
-                    Text(formatAmount(last.cumulativeExpenses))
-                        .font(.caption2)
-                        .foregroundColor(.red)
-                }
-            }
-        }
-        .chartXScale(domain: 1...daysInMonth)
-        .chartXAxis {
-            AxisMarks(values: labelDays) { value in
-                AxisGridLine()
-                AxisValueLabel {
-                    if let day = value.as(Int.self) {
-                        Text("\(month)/\(day)")
+                if let last = balances.last {
+                    PointMark(
+                        x: .value("日付", balances.count),
+                        y: .value("金額", last.cumulativeIncome)
+                    )
+                    .foregroundStyle(.clear)
+                    .annotation(position: .topLeading) {
+                        Text(formatAmount(last.cumulativeIncome))
                             .font(.caption2)
+                            .foregroundColor(.blue)
+                    }
+
+                    PointMark(
+                        x: .value("日付", balances.count),
+                        y: .value("金額", last.cumulativeExpenses)
+                    )
+                    .foregroundStyle(.clear)
+                    .annotation(position: .topLeading) {
+                        Text(formatAmount(last.cumulativeExpenses))
+                            .font(.caption2)
+                            .foregroundColor(.red)
                     }
                 }
             }
+            .chartXScale(domain: 1...daysInMonth)
+            .chartXAxis {
+                AxisMarks(values: labelDays) { value in
+                    AxisGridLine()
+                    AxisValueLabel {
+                        if let day = value.as(Int.self) {
+                            Text("\(month)/\(day)")
+                                .font(.caption2)
+                        }
+                    }
+                }
+            }
+            .chartYAxis(.hidden)
+            .chartLegend(.hidden)
+            .frame(height: graphHeight)
         }
-        .chartYAxis(.hidden)
-        .chartLegend(.hidden)
-        .frame(height: graphHeight)
     }
 
     private func formatAmount(_ value: Double) -> String {

--- a/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
@@ -23,7 +23,9 @@ struct TopHomeView: View {
                         month: viewModel.selectedMonth,
                         dailyBalances: viewModel.dailyBalances,
                         onPreviousMonth: { viewModel.goToPreviousMonth() },
-                        onNextMonth: { viewModel.goToNextMonth() }
+                        onNextMonth: { viewModel.goToNextMonth() },
+                        onSelectYearMonth: { year, month in viewModel.selectYearMonth(year: year, month: month) },
+                        availableYearMonths: viewModel.availableYearMonths
                     )
                     .padding(.vertical, 8)
                 }
@@ -58,6 +60,7 @@ struct TopHomeView: View {
         .onAppear {
             viewModel.loadMonthlyBalance()
             viewModel.loadDailyBalances(year: viewModel.selectedYear, month: viewModel.selectedMonth)
+            viewModel.loadAvailableYearMonths()
         }
         .onChange(of: showingSheetToInputHome) { oldValue, newValue in
             if !newValue {

--- a/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
@@ -19,9 +19,11 @@ struct TopHomeView: View {
                     BalanceView(type: .income, balance: viewModel.monthlyIncome)
                     BalanceView(type: .expenses, balance: viewModel.monthlyExpenses)
                     BalanceGraphView(
-                        year: Calendar.current.component(.year, from: Date()),
-                        month: Calendar.current.component(.month, from: Date()),
-                        dailyBalances: viewModel.dailyBalances
+                        year: viewModel.selectedYear,
+                        month: viewModel.selectedMonth,
+                        dailyBalances: viewModel.dailyBalances,
+                        onPreviousMonth: { viewModel.goToPreviousMonth() },
+                        onNextMonth: { viewModel.goToNextMonth() }
                     )
                     .padding(.vertical, 8)
                 }
@@ -54,19 +56,13 @@ struct TopHomeView: View {
             .presentationDetents([.fraction(0.75), .large])
         }
         .onAppear {
-            let now = Date()
-            let year = Calendar.current.component(.year, from: now)
-            let month = Calendar.current.component(.month, from: now)
             viewModel.loadMonthlyBalance()
-            viewModel.loadDailyBalances(year: year, month: month)
+            viewModel.loadDailyBalances(year: viewModel.selectedYear, month: viewModel.selectedMonth)
         }
         .onChange(of: showingSheetToInputHome) { oldValue, newValue in
             if !newValue {
-                let now = Date()
-                let year = Calendar.current.component(.year, from: now)
-                let month = Calendar.current.component(.month, from: now)
                 viewModel.loadMonthlyBalance()
-                viewModel.loadDailyBalances(year: year, month: month)
+                viewModel.loadDailyBalances(year: viewModel.selectedYear, month: viewModel.selectedMonth)
             }
         }
     }

--- a/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
@@ -18,8 +18,12 @@ struct TopHomeView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     BalanceView(type: .income, balance: viewModel.monthlyIncome)
                     BalanceView(type: .expenses, balance: viewModel.monthlyExpenses)
-                    BalanceGraphView.dummyPreview
-                        .padding(.vertical, 8)
+                    BalanceGraphView(
+                        year: Calendar.current.component(.year, from: Date()),
+                        month: Calendar.current.component(.month, from: Date()),
+                        dailyBalances: viewModel.dailyBalances
+                    )
+                    .padding(.vertical, 8)
                 }
             }
             
@@ -50,11 +54,19 @@ struct TopHomeView: View {
             .presentationDetents([.fraction(0.75), .large])
         }
         .onAppear {
+            let now = Date()
+            let year = Calendar.current.component(.year, from: now)
+            let month = Calendar.current.component(.month, from: now)
             viewModel.loadMonthlyBalance()
+            viewModel.loadDailyBalances(year: year, month: month)
         }
         .onChange(of: showingSheetToInputHome) { oldValue, newValue in
             if !newValue {
+                let now = Date()
+                let year = Calendar.current.component(.year, from: now)
+                let month = Calendar.current.component(.month, from: now)
                 viewModel.loadMonthlyBalance()
+                viewModel.loadDailyBalances(year: year, month: month)
             }
         }
     }

--- a/project/iOS/imitate/ViewModel/TopHomeViewModel.swift
+++ b/project/iOS/imitate/ViewModel/TopHomeViewModel.swift
@@ -12,12 +12,41 @@ class TopHomeViewModel: ObservableObject {
 
     @Published var monthlyIncome: String = "0"
     @Published var monthlyExpenses: String = "0"
+    @Published var dailyBalances: [DailyBalance] = []
     @Published var isLoading: Bool = false
 
     private let repository: BalanceRecordRepositoryProtocol
 
     init(repository: BalanceRecordRepositoryProtocol = BalanceRecordRepository.shared) {
         self.repository = repository
+    }
+
+    func loadDailyBalances(year: Int, month: Int) {
+        repository.getDailyBalanceData(
+            year: year,
+            month: month,
+            onSuccess: { [weak self] data in
+                let balances: [DailyBalance] = data.compactMap { item in
+                    guard let dateStr = item["date"] as? String,
+                          let date = DateFormatter.yyyyMMdd.date(from: dateStr),
+                          let income = item["cumulativeIncome"] as? Int,
+                          let expenses = item["cumulativeExpenses"] as? Int else { return nil }
+                    return DailyBalance(
+                        date: date,
+                        cumulativeIncome: Double(income),
+                        cumulativeExpenses: Double(expenses)
+                    )
+                }
+                DispatchQueue.main.async {
+                    self?.dailyBalances = balances
+                }
+            },
+            onFailure: { [weak self] in
+                DispatchQueue.main.async {
+                    self?.dailyBalances = []
+                }
+            }
+        )
     }
 
     func loadMonthlyBalance() {

--- a/project/iOS/imitate/ViewModel/TopHomeViewModel.swift
+++ b/project/iOS/imitate/ViewModel/TopHomeViewModel.swift
@@ -13,6 +13,7 @@ class TopHomeViewModel: ObservableObject {
     @Published var monthlyIncome: String = "0"
     @Published var monthlyExpenses: String = "0"
     @Published var dailyBalances: [DailyBalance] = []
+    @Published var availableYearMonths: [(year: Int, month: Int)] = []
     @Published var isLoading: Bool = false
     @Published var selectedYear: Int = Calendar.current.component(.year, from: Date())
     @Published var selectedMonth: Int = Calendar.current.component(.month, from: Date())
@@ -23,17 +24,46 @@ class TopHomeViewModel: ObservableObject {
         self.repository = repository
     }
 
-    func goToPreviousMonth() { shiftMonth(by: -1) }
-    func goToNextMonth() { shiftMonth(by: 1) }
+    func loadAvailableYearMonths() {
+        repository.getAvailableYearMonths(
+            onSuccess: { [weak self] yearMonths in
+                let parsed: [(year: Int, month: Int)] = yearMonths.compactMap { str in
+                    let parts = str.split(separator: "-")
+                    guard parts.count == 2,
+                          let year = Int(parts[0]),
+                          let month = Int(parts[1]) else { return nil }
+                    return (year: year, month: month)
+                }
+                DispatchQueue.main.async {
+                    self?.availableYearMonths = parsed
+                }
+            },
+            onFailure: { [weak self] in
+                DispatchQueue.main.async {
+                    self?.availableYearMonths = []
+                }
+            }
+        )
+    }
 
-    private func shiftMonth(by value: Int) {
-        let calendar = Calendar.current
-        let components = DateComponents(year: selectedYear, month: selectedMonth)
-        guard let currentDate = calendar.date(from: components),
-              let newDate = calendar.date(byAdding: .month, value: value, to: currentDate) else { return }
-        selectedYear = calendar.component(.year, from: newDate)
-        selectedMonth = calendar.component(.month, from: newDate)
-        loadDailyBalances(year: selectedYear, month: selectedMonth)
+    func goToPreviousMonth() {
+        guard let currentIndex = availableYearMonths.firstIndex(where: { $0.year == selectedYear && $0.month == selectedMonth }),
+              currentIndex > 0 else { return }
+        let previous = availableYearMonths[currentIndex - 1]
+        selectYearMonth(year: previous.year, month: previous.month)
+    }
+
+    func goToNextMonth() {
+        guard let currentIndex = availableYearMonths.firstIndex(where: { $0.year == selectedYear && $0.month == selectedMonth }),
+              currentIndex < availableYearMonths.count - 1 else { return }
+        let next = availableYearMonths[currentIndex + 1]
+        selectYearMonth(year: next.year, month: next.month)
+    }
+
+    func selectYearMonth(year: Int, month: Int) {
+        selectedYear = year
+        selectedMonth = month
+        loadDailyBalances(year: year, month: month)
     }
 
     func loadDailyBalances(year: Int, month: Int) {

--- a/project/iOS/imitate/ViewModel/TopHomeViewModel.swift
+++ b/project/iOS/imitate/ViewModel/TopHomeViewModel.swift
@@ -14,11 +14,26 @@ class TopHomeViewModel: ObservableObject {
     @Published var monthlyExpenses: String = "0"
     @Published var dailyBalances: [DailyBalance] = []
     @Published var isLoading: Bool = false
+    @Published var selectedYear: Int = Calendar.current.component(.year, from: Date())
+    @Published var selectedMonth: Int = Calendar.current.component(.month, from: Date())
 
     private let repository: BalanceRecordRepositoryProtocol
 
     init(repository: BalanceRecordRepositoryProtocol = BalanceRecordRepository.shared) {
         self.repository = repository
+    }
+
+    func goToPreviousMonth() { shiftMonth(by: -1) }
+    func goToNextMonth() { shiftMonth(by: 1) }
+
+    private func shiftMonth(by value: Int) {
+        let calendar = Calendar.current
+        let components = DateComponents(year: selectedYear, month: selectedMonth)
+        guard let currentDate = calendar.date(from: components),
+              let newDate = calendar.date(byAdding: .month, value: value, to: currentDate) else { return }
+        selectedYear = calendar.component(.year, from: newDate)
+        selectedMonth = calendar.component(.month, from: newDate)
+        loadDailyBalances(year: selectedYear, month: selectedMonth)
     }
 
     func loadDailyBalances(year: Int, month: Int) {

--- a/project/iOS/imitateTests/HistoryHomeViewModelTests.swift
+++ b/project/iOS/imitateTests/HistoryHomeViewModelTests.swift
@@ -179,6 +179,10 @@ final class HistoryHomeViewModelTests: XCTestCase {
 
 /// テスト用のモック BalanceRecordRepository
 class MockBalanceRecordRepository: BalanceRecordRepositoryProtocol {
+    func getAvailableYearMonths(onSuccess: @escaping (([String]) -> Void), onFailure: @escaping (() -> Void)) {
+        // TODO: 別途テスト作成
+    }
+    
     func getDailyBalanceData(year: Int, month: Int, onSuccess: @escaping (([[String : Any]]) -> Void), onFailure: @escaping (() -> Void)) {
         // TODO: 別途テスト作成
     }

--- a/project/iOS/imitateTests/HistoryHomeViewModelTests.swift
+++ b/project/iOS/imitateTests/HistoryHomeViewModelTests.swift
@@ -179,6 +179,10 @@ final class HistoryHomeViewModelTests: XCTestCase {
 
 /// テスト用のモック BalanceRecordRepository
 class MockBalanceRecordRepository: BalanceRecordRepositoryProtocol {
+    func getDailyBalanceData(year: Int, month: Int, onSuccess: @escaping (([[String : Any]]) -> Void), onFailure: @escaping (() -> Void)) {
+        // TODO: 別途テスト作成
+    }
+    
     func getMonthlyIncome(onSuccess: @escaping ((Int) -> Void), onFailure: @escaping (() -> Void)) {
         // TODO: 別途テスト作成
     }


### PR DESCRIPTION
## Summary
- Flutter SDK に日別累計収支データ取得メソッド (`getDailyBalanceData`) を追加
- Flutter SDK に `intl` パッケージを導入し日付フォーマットを `DateFormat` に統一
- iOS側の `BalanceRecordRepository` に対応するメソッドを追加し Flutter と連携
- `TopHomeViewModel` にグラフ用データ管理・月切り替えロジックを実装
- グラフの月切り替え（`< >`ボタン・年月ピッカー）を実装
- ピッカーはレコードが存在する年月のみ表示
- データなし時は「データがありません」を表示し、ボタン類を非表示にする
- グラフの状態管理を `BalanceGraphState` enum で Container に集約

## Test plan
- [ ] Xcodeでビルドが通ること
- [ ] `<` `>` ボタンで前後の月に切り替えられること
- [ ] 年月ボタンを押下するとピッカーが表示され、レコードが存在する年月のみ選択できること
- [ ] データが存在しない場合「データがありません」が表示されること
- [ ] データが存在しない場合、ヘッダーのボタン類が非表示になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)