### PR TITLE
【iOS】ログ設計の実装

### DIFF
--- a/project/iOS/imitate.xcodeproj/project.pbxproj
+++ b/project/iOS/imitate.xcodeproj/project.pbxproj
@@ -89,6 +89,9 @@
 		B9E0D79A2F85344B00CF247C /* DictionaryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E0D7992F85344B00CF247C /* DictionaryExtension.swift */; };
 		B9E0D79B2F85344B00CF247C /* DictionaryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E0D7992F85344B00CF247C /* DictionaryExtension.swift */; };
 		B9E0D79C2F85344B00CF247C /* DictionaryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E0D7992F85344B00CF247C /* DictionaryExtension.swift */; };
+		B9AB12352F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
+		B9AB12362F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
+		B9AB12372F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -158,6 +161,7 @@
 		B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceGraphView.swift; sourceTree = "<group>"; };
 		B9C191CD2F081E9400AFE3C3 /* BalanceRecordRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceRecordRepository.swift; sourceTree = "<group>"; };
 		B9D08D2F2E520ED20074BFD5 /* FlutterEngineManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterEngineManager.swift; sourceTree = "<group>"; };
+		B9AB12342F9C000000000001 /* AppLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogger.swift; sourceTree = "<group>"; };
 		B9DEC5562F1BF4AC0085FEC5 /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		B9DEC5592F1D525C0085FEC5 /* HistoryRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryRowView.swift; sourceTree = "<group>"; };
 		B9E0D7992F85344B00CF247C /* DictionaryExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtension.swift; sourceTree = "<group>"; };
@@ -341,6 +345,7 @@
 			isa = PBXGroup;
 			children = (
 				B9D08D2F2E520ED20074BFD5 /* FlutterEngineManager.swift */,
+				B9AB12342F9C000000000001 /* AppLogger.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -521,6 +526,7 @@
 				B9C191A42EFFDBD200AFE3C3 /* BaseHomeView.swift in Sources */,
 				B9DEC55A2F1D525C0085FEC5 /* HistoryRowView.swift in Sources */,
 				B9D08D302E520ED20074BFD5 /* FlutterEngineManager.swift in Sources */,
+				B9AB12352F9C000000000001 /* AppLogger.swift in Sources */,
 				B9C166622F26772400A3BEC5 /* BalanceRecordInfo.swift in Sources */,
 				B9DEC5572F1BF4AC0085FEC5 /* DateExtension.swift in Sources */,
 				B95E7F5B2F8558C10071D91A /* HistoryHomeViewModel.swift in Sources */,
@@ -558,6 +564,7 @@
 				B95E7F642F8558D70071D91A /* HistoryHomeViewModelTests.swift in Sources */,
 				B9C166632F267E7500A3BEC5 /* BalanceRecordInfo.swift in Sources */,
 				B9C191AF2EFFDC3300AFE3C3 /* FlutterEngineManager.swift in Sources */,
+				B9AB12362F9C000000000001 /* AppLogger.swift in Sources */,
 				B9C191CF2F081E9400AFE3C3 /* BalanceRecordRepository.swift in Sources */,
 				B9DEC55D2F1D53930085FEC5 /* DateExtension.swift in Sources */,
 				B9C191BA2EFFDDB700AFE3C3 /* InputHomeView.swift in Sources */,
@@ -587,6 +594,7 @@
 				B961A2672F097AEB00B2989C /* InputBalanceSegmentView.swift in Sources */,
 				B9C191C32EFFDE4E00AFE3C3 /* HistoryHomeView.swift in Sources */,
 				B9C191B02EFFDC3300AFE3C3 /* FlutterEngineManager.swift in Sources */,
+				B9AB12372F9C000000000001 /* AppLogger.swift in Sources */,
 				B9E0D79C2F85344B00CF247C /* DictionaryExtension.swift in Sources */,
 				B9C191A62EFFDC2100AFE3C3 /* AppDelegate.swift in Sources */,
 				B9C191D02F081E9400AFE3C3 /* BalanceRecordRepository.swift in Sources */,

--- a/project/iOS/imitate.xcodeproj/project.pbxproj
+++ b/project/iOS/imitate.xcodeproj/project.pbxproj
@@ -92,6 +92,9 @@
 		B9AB12352F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
 		B9AB12362F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
 		B9AB12372F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
+		B9AB12392F9C000000000002 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12382F9C000000000002 /* ViewExtension.swift */; };
+		B9AB123A2F9C000000000002 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12382F9C000000000002 /* ViewExtension.swift */; };
+		B9AB123B2F9C000000000002 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12382F9C000000000002 /* ViewExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -162,6 +165,7 @@
 		B9C191CD2F081E9400AFE3C3 /* BalanceRecordRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceRecordRepository.swift; sourceTree = "<group>"; };
 		B9D08D2F2E520ED20074BFD5 /* FlutterEngineManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterEngineManager.swift; sourceTree = "<group>"; };
 		B9AB12342F9C000000000001 /* AppLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogger.swift; sourceTree = "<group>"; };
+		B9AB12382F9C000000000002 /* ViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
 		B9DEC5562F1BF4AC0085FEC5 /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		B9DEC5592F1D525C0085FEC5 /* HistoryRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryRowView.swift; sourceTree = "<group>"; };
 		B9E0D7992F85344B00CF247C /* DictionaryExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtension.swift; sourceTree = "<group>"; };
@@ -337,6 +341,7 @@
 			children = (
 				B9E0D7992F85344B00CF247C /* DictionaryExtension.swift */,
 				B9DEC5562F1BF4AC0085FEC5 /* DateExtension.swift */,
+				B9AB12382F9C000000000002 /* ViewExtension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -527,6 +532,7 @@
 				B9DEC55A2F1D525C0085FEC5 /* HistoryRowView.swift in Sources */,
 				B9D08D302E520ED20074BFD5 /* FlutterEngineManager.swift in Sources */,
 				B9AB12352F9C000000000001 /* AppLogger.swift in Sources */,
+				B9AB12392F9C000000000002 /* ViewExtension.swift in Sources */,
 				B9C166622F26772400A3BEC5 /* BalanceRecordInfo.swift in Sources */,
 				B9DEC5572F1BF4AC0085FEC5 /* DateExtension.swift in Sources */,
 				B95E7F5B2F8558C10071D91A /* HistoryHomeViewModel.swift in Sources */,
@@ -565,6 +571,7 @@
 				B9C166632F267E7500A3BEC5 /* BalanceRecordInfo.swift in Sources */,
 				B9C191AF2EFFDC3300AFE3C3 /* FlutterEngineManager.swift in Sources */,
 				B9AB12362F9C000000000001 /* AppLogger.swift in Sources */,
+				B9AB123A2F9C000000000002 /* ViewExtension.swift in Sources */,
 				B9C191CF2F081E9400AFE3C3 /* BalanceRecordRepository.swift in Sources */,
 				B9DEC55D2F1D53930085FEC5 /* DateExtension.swift in Sources */,
 				B9C191BA2EFFDDB700AFE3C3 /* InputHomeView.swift in Sources */,
@@ -595,6 +602,7 @@
 				B9C191C32EFFDE4E00AFE3C3 /* HistoryHomeView.swift in Sources */,
 				B9C191B02EFFDC3300AFE3C3 /* FlutterEngineManager.swift in Sources */,
 				B9AB12372F9C000000000001 /* AppLogger.swift in Sources */,
+				B9AB123B2F9C000000000002 /* ViewExtension.swift in Sources */,
 				B9E0D79C2F85344B00CF247C /* DictionaryExtension.swift in Sources */,
 				B9C191A62EFFDC2100AFE3C3 /* AppDelegate.swift in Sources */,
 				B9C191D02F081E9400AFE3C3 /* BalanceRecordRepository.swift in Sources */,

--- a/project/iOS/imitate/Extension/ViewExtension.swift
+++ b/project/iOS/imitate/Extension/ViewExtension.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+extension View {
+    func logScreenAppeared(file: String = #fileID) -> some View {
+        self.onAppear {
+            AppLogger.shared.screenAppeared(file: file)
+        }
+    }
+}

--- a/project/iOS/imitate/Manager/AppLogger.swift
+++ b/project/iOS/imitate/Manager/AppLogger.swift
@@ -42,7 +42,7 @@ final class AppLogger {
 
     // MARK: - Action
 
-    func buttonTapped(_ button: String, on screen: String) {
+    func buttonTapped(_ button: String, on screen: String = #fileID) {
         let message = "【iOS】[\(screen)] '\(button)' tapped"
         actionLogger.debug("\(message, privacy: .public)")
         forward(level: .debug, category: .action, message: message)

--- a/project/iOS/imitate/Manager/AppLogger.swift
+++ b/project/iOS/imitate/Manager/AppLogger.swift
@@ -1,0 +1,77 @@
+import OSLog
+
+// MARK: - Log Destination (for future Firebase integration)
+
+protocol LogDestination {
+    func log(level: AppLogger.Level, category: AppLogger.Category, message: String)
+}
+
+// MARK: - AppLogger
+
+final class AppLogger {
+
+    enum Level {
+        case debug, info, warning, error
+    }
+
+    enum Category: String {
+        case screen  = "Screen"
+        case action  = "Action"
+        case network = "Network"
+    }
+
+    static let shared = AppLogger()
+
+    var destinations: [LogDestination] = []
+
+    private let subsystem = Bundle.main.bundleIdentifier ?? "com.imitate.app"
+
+    private lazy var screenLogger  = Logger(subsystem: subsystem, category: Category.screen.rawValue)
+    private lazy var actionLogger  = Logger(subsystem: subsystem, category: Category.action.rawValue)
+    private lazy var networkLogger = Logger(subsystem: subsystem, category: Category.network.rawValue)
+
+    private init() {}
+
+    // MARK: - Screen
+
+    func screenAppeared(_ screen: String) {
+        let message = "【iOS】[\(screen)] appeared"
+        screenLogger.debug("\(message, privacy: .public)")
+        forward(level: .debug, category: .screen, message: message)
+    }
+
+    // MARK: - Action
+
+    func buttonTapped(_ button: String, on screen: String) {
+        let message = "【iOS】[\(screen)] '\(button)' tapped"
+        actionLogger.debug("\(message, privacy: .public)")
+        forward(level: .debug, category: .action, message: message)
+    }
+
+    // MARK: - Network
+
+    func networkRequest(_ method: String) {
+        let message = "【iOS】[\(method)] requesting"
+        networkLogger.debug("\(message, privacy: .public)")
+        forward(level: .debug, category: .network, message: message)
+    }
+
+    func networkSuccess(_ method: String) {
+        let message = "【iOS】[\(method)] success"
+        networkLogger.debug("\(message, privacy: .public)")
+        forward(level: .debug, category: .network, message: message)
+    }
+
+    func networkFailure(_ method: String, error: String) {
+        let message = "【iOS】[\(method)] failure: \(error)"
+        networkLogger.debug("\(message, privacy: .public)")
+        forward(level: .debug, category: .network, message: message)
+    }
+
+    // MARK: - Private
+
+    // TODO: Firebase導入時に FirebaseLogDestination を実装し destinations に追加する
+    private func forward(level: Level, category: Category, message: String) {
+        destinations.forEach { $0.log(level: level, category: category, message: message) }
+    }
+}

--- a/project/iOS/imitate/Manager/AppLogger.swift
+++ b/project/iOS/imitate/Manager/AppLogger.swift
@@ -42,8 +42,8 @@ final class AppLogger {
 
     // MARK: - Action
 
-    func buttonTapped(_ button: String, on screen: String = #fileID) {
-        let message = "【iOS】[\(screen)] '\(button)' tapped"
+    func userAction(_ action: String, on screen: String = #fileID) {
+        let message = "【iOS】[\(screen)] '\(action)' action"
         actionLogger.debug("\(message, privacy: .public)")
         forward(level: .debug, category: .action, message: message)
     }

--- a/project/iOS/imitate/Manager/AppLogger.swift
+++ b/project/iOS/imitate/Manager/AppLogger.swift
@@ -34,8 +34,8 @@ final class AppLogger {
 
     // MARK: - Screen
 
-    func screenAppeared(_ screen: String) {
-        let message = "【iOS】[\(screen)] appeared"
+    func screenAppeared(file: String = #fileID) {
+        let message = "【iOS】[\(file)] appeared"
         screenLogger.debug("\(message, privacy: .public)")
         forward(level: .debug, category: .screen, message: message)
     }

--- a/project/iOS/imitate/Manager/AppLogger.swift
+++ b/project/iOS/imitate/Manager/AppLogger.swift
@@ -17,7 +17,7 @@ final class AppLogger {
     enum Category: String {
         case screen  = "Screen"
         case action  = "Action"
-        case network = "Network"
+        case channel = "Channel"
     }
 
     static let shared = AppLogger()
@@ -28,7 +28,7 @@ final class AppLogger {
 
     private lazy var screenLogger  = Logger(subsystem: subsystem, category: Category.screen.rawValue)
     private lazy var actionLogger  = Logger(subsystem: subsystem, category: Category.action.rawValue)
-    private lazy var networkLogger = Logger(subsystem: subsystem, category: Category.network.rawValue)
+    private lazy var channelLogger = Logger(subsystem: subsystem, category: Category.channel.rawValue)
 
     private init() {}
 
@@ -48,24 +48,24 @@ final class AppLogger {
         forward(level: .debug, category: .action, message: message)
     }
 
-    // MARK: - Network
+    // MARK: - Channel
 
-    func networkRequest(_ method: String) {
-        let message = "【iOS】[\(method)] requesting"
-        networkLogger.debug("\(message, privacy: .public)")
-        forward(level: .debug, category: .network, message: message)
+    func channelRequest(_ method: String) {
+        let message = "【iOS】[\(method)] channel requesting"
+        channelLogger.debug("\(message, privacy: .public)")
+        forward(level: .debug, category: .channel, message: message)
     }
 
-    func networkSuccess(_ method: String) {
-        let message = "【iOS】[\(method)] success"
-        networkLogger.debug("\(message, privacy: .public)")
-        forward(level: .debug, category: .network, message: message)
+    func channelSuccess(_ method: String) {
+        let message = "【iOS】[\(method)] channel success"
+        channelLogger.debug("\(message, privacy: .public)")
+        forward(level: .debug, category: .channel, message: message)
     }
 
-    func networkFailure(_ method: String, error: String) {
-        let message = "【iOS】[\(method)] failure: \(error)"
-        networkLogger.debug("\(message, privacy: .public)")
-        forward(level: .debug, category: .network, message: message)
+    func channelFailure(_ method: String, error: String) {
+        let message = "【iOS】[\(method)] channel failure: \(error)"
+        channelLogger.debug("\(message, privacy: .public)")
+        forward(level: .debug, category: .channel, message: message)
     }
 
     // MARK: - Private

--- a/project/iOS/imitate/Model/Repository/BalanceRecordRepository.swift
+++ b/project/iOS/imitate/Model/Repository/BalanceRecordRepository.swift
@@ -28,41 +28,41 @@ class BalanceRecordRepository: BalanceRecordRepositoryProtocol {
 
     func selectAll(onSuccess: @escaping (([[String: Any]]?) -> Void),
                    onFailure: @escaping (() -> Void)) {
-        AppLogger.shared.networkRequest("BalanceRecordRepository.selectAll")
+        AppLogger.shared.channelRequest("BalanceRecordRepository.selectAll")
         FlutterEngineManager.shared.channel?.invokeMethod("selectAll", arguments: nil) { result in
             if let result = result as? [[String: Any]] {
-                AppLogger.shared.networkSuccess("BalanceRecordRepository.selectAll")
+                AppLogger.shared.channelSuccess("BalanceRecordRepository.selectAll")
                 onSuccess(result)
             } else if let error = result as? FlutterError {
-                AppLogger.shared.networkFailure("BalanceRecordRepository.selectAll", error: error.message ?? "Unknown error")
+                AppLogger.shared.channelFailure("BalanceRecordRepository.selectAll", error: error.message ?? "Unknown error")
                 onFailure()
             } else if result == nil {
-                AppLogger.shared.networkFailure("BalanceRecordRepository.selectAll", error: "No result returned")
+                AppLogger.shared.channelFailure("BalanceRecordRepository.selectAll", error: "No result returned")
                 onFailure()
             } else {
-                AppLogger.shared.networkFailure("BalanceRecordRepository.selectAll", error: "Unexpected result type")
+                AppLogger.shared.channelFailure("BalanceRecordRepository.selectAll", error: "Unexpected result type")
                 onFailure()
             }
         }
     }
 
     func insertRecord(arguments: [String: Any]) {
-        AppLogger.shared.networkRequest("BalanceRecordRepository.insert")
+        AppLogger.shared.channelRequest("BalanceRecordRepository.insert")
         FlutterEngineManager.shared.channel?.invokeMethod("insert", arguments: arguments)
     }
 
     func getMonthlyIncome(onSuccess: @escaping ((Int) -> Void),
                           onFailure: @escaping (() -> Void)) {
-        AppLogger.shared.networkRequest("BalanceRecordRepository.getMonthlyIncome")
+        AppLogger.shared.channelRequest("BalanceRecordRepository.getMonthlyIncome")
         FlutterEngineManager.shared.channel?.invokeMethod("getMonthlyIncome", arguments: nil) { result in
             if let income = result as? Int {
-                AppLogger.shared.networkSuccess("BalanceRecordRepository.getMonthlyIncome")
+                AppLogger.shared.channelSuccess("BalanceRecordRepository.getMonthlyIncome")
                 onSuccess(income)
             } else if let error = result as? FlutterError {
-                AppLogger.shared.networkFailure("BalanceRecordRepository.getMonthlyIncome", error: error.message ?? "Unknown error")
+                AppLogger.shared.channelFailure("BalanceRecordRepository.getMonthlyIncome", error: error.message ?? "Unknown error")
                 onFailure()
             } else {
-                AppLogger.shared.networkFailure("BalanceRecordRepository.getMonthlyIncome", error: "Unexpected result type")
+                AppLogger.shared.channelFailure("BalanceRecordRepository.getMonthlyIncome", error: "Unexpected result type")
                 onFailure()
             }
         }
@@ -70,16 +70,16 @@ class BalanceRecordRepository: BalanceRecordRepositoryProtocol {
 
     func getMonthlyExpenses(onSuccess: @escaping ((Int) -> Void),
                             onFailure: @escaping (() -> Void)) {
-        AppLogger.shared.networkRequest("BalanceRecordRepository.getMonthlyExpenses")
+        AppLogger.shared.channelRequest("BalanceRecordRepository.getMonthlyExpenses")
         FlutterEngineManager.shared.channel?.invokeMethod("getMonthlyExpenses", arguments: nil) { result in
             if let expenses = result as? Int {
-                AppLogger.shared.networkSuccess("BalanceRecordRepository.getMonthlyExpenses")
+                AppLogger.shared.channelSuccess("BalanceRecordRepository.getMonthlyExpenses")
                 onSuccess(expenses)
             } else if let error = result as? FlutterError {
-                AppLogger.shared.networkFailure("BalanceRecordRepository.getMonthlyExpenses", error: error.message ?? "Unknown error")
+                AppLogger.shared.channelFailure("BalanceRecordRepository.getMonthlyExpenses", error: error.message ?? "Unknown error")
                 onFailure()
             } else {
-                AppLogger.shared.networkFailure("BalanceRecordRepository.getMonthlyExpenses", error: "Unexpected result type")
+                AppLogger.shared.channelFailure("BalanceRecordRepository.getMonthlyExpenses", error: "Unexpected result type")
                 onFailure()
             }
         }
@@ -88,17 +88,17 @@ class BalanceRecordRepository: BalanceRecordRepositoryProtocol {
     func getDailyBalanceData(year: Int, month: Int,
                              onSuccess: @escaping (([[String: Any]]) -> Void),
                              onFailure: @escaping (() -> Void)) {
-        AppLogger.shared.networkRequest("BalanceRecordRepository.getDailyBalanceData")
+        AppLogger.shared.channelRequest("BalanceRecordRepository.getDailyBalanceData")
         let arguments: [String: Any] = ["year": year, "month": month]
         FlutterEngineManager.shared.channel?.invokeMethod("getDailyBalanceData", arguments: arguments) { result in
             if let data = result as? [[String: Any]] {
-                AppLogger.shared.networkSuccess("BalanceRecordRepository.getDailyBalanceData")
+                AppLogger.shared.channelSuccess("BalanceRecordRepository.getDailyBalanceData")
                 onSuccess(data)
             } else if let error = result as? FlutterError {
-                AppLogger.shared.networkFailure("BalanceRecordRepository.getDailyBalanceData", error: error.message ?? "Unknown error")
+                AppLogger.shared.channelFailure("BalanceRecordRepository.getDailyBalanceData", error: error.message ?? "Unknown error")
                 onFailure()
             } else {
-                AppLogger.shared.networkFailure("BalanceRecordRepository.getDailyBalanceData", error: "Unexpected result type")
+                AppLogger.shared.channelFailure("BalanceRecordRepository.getDailyBalanceData", error: "Unexpected result type")
                 onFailure()
             }
         }
@@ -106,16 +106,16 @@ class BalanceRecordRepository: BalanceRecordRepositoryProtocol {
 
     func getAvailableYearMonths(onSuccess: @escaping (([String]) -> Void),
                                 onFailure: @escaping (() -> Void)) {
-        AppLogger.shared.networkRequest("BalanceRecordRepository.getAvailableYearMonths")
+        AppLogger.shared.channelRequest("BalanceRecordRepository.getAvailableYearMonths")
         FlutterEngineManager.shared.channel?.invokeMethod("getAvailableYearMonths", arguments: nil) { result in
             if let yearMonths = result as? [String] {
-                AppLogger.shared.networkSuccess("BalanceRecordRepository.getAvailableYearMonths")
+                AppLogger.shared.channelSuccess("BalanceRecordRepository.getAvailableYearMonths")
                 onSuccess(yearMonths)
             } else if let error = result as? FlutterError {
-                AppLogger.shared.networkFailure("BalanceRecordRepository.getAvailableYearMonths", error: error.message ?? "Unknown error")
+                AppLogger.shared.channelFailure("BalanceRecordRepository.getAvailableYearMonths", error: error.message ?? "Unknown error")
                 onFailure()
             } else {
-                AppLogger.shared.networkFailure("BalanceRecordRepository.getAvailableYearMonths", error: "Unexpected result type")
+                AppLogger.shared.channelFailure("BalanceRecordRepository.getAvailableYearMonths", error: "Unexpected result type")
                 onFailure()
             }
         }

--- a/project/iOS/imitate/Model/Repository/BalanceRecordRepository.swift
+++ b/project/iOS/imitate/Model/Repository/BalanceRecordRepository.swift
@@ -25,41 +25,44 @@ protocol BalanceRecordRepositoryProtocol {
 class BalanceRecordRepository: BalanceRecordRepositoryProtocol {
 
     static let shared = BalanceRecordRepository()
-    
+
     func selectAll(onSuccess: @escaping (([[String: Any]]?) -> Void),
                    onFailure: @escaping (() -> Void)) {
+        AppLogger.shared.networkRequest("BalanceRecordRepository.selectAll")
         FlutterEngineManager.shared.channel?.invokeMethod("selectAll", arguments: nil) { result in
-            
             if let result = result as? [[String: Any]] {
+                AppLogger.shared.networkSuccess("BalanceRecordRepository.selectAll")
                 onSuccess(result)
             } else if let error = result as? FlutterError {
-                print("Error: \(error.message ?? "Unknown error")")
+                AppLogger.shared.networkFailure("BalanceRecordRepository.selectAll", error: error.message ?? "Unknown error")
                 onFailure()
             } else if result == nil {
-                print("No result returned")
+                AppLogger.shared.networkFailure("BalanceRecordRepository.selectAll", error: "No result returned")
                 onFailure()
             } else {
-                print("failed selectAll")
+                AppLogger.shared.networkFailure("BalanceRecordRepository.selectAll", error: "Unexpected result type")
                 onFailure()
             }
         }
     }
-    
+
     func insertRecord(arguments: [String: Any]) {
+        AppLogger.shared.networkRequest("BalanceRecordRepository.insert")
         FlutterEngineManager.shared.channel?.invokeMethod("insert", arguments: arguments)
     }
 
     func getMonthlyIncome(onSuccess: @escaping ((Int) -> Void),
                           onFailure: @escaping (() -> Void)) {
+        AppLogger.shared.networkRequest("BalanceRecordRepository.getMonthlyIncome")
         FlutterEngineManager.shared.channel?.invokeMethod("getMonthlyIncome", arguments: nil) { result in
-
             if let income = result as? Int {
+                AppLogger.shared.networkSuccess("BalanceRecordRepository.getMonthlyIncome")
                 onSuccess(income)
             } else if let error = result as? FlutterError {
-                print("Error: \(error.message ?? "Unknown error")")
+                AppLogger.shared.networkFailure("BalanceRecordRepository.getMonthlyIncome", error: error.message ?? "Unknown error")
                 onFailure()
             } else {
-                print("failed getMonthlyIncome")
+                AppLogger.shared.networkFailure("BalanceRecordRepository.getMonthlyIncome", error: "Unexpected result type")
                 onFailure()
             }
         }
@@ -67,15 +70,16 @@ class BalanceRecordRepository: BalanceRecordRepositoryProtocol {
 
     func getMonthlyExpenses(onSuccess: @escaping ((Int) -> Void),
                             onFailure: @escaping (() -> Void)) {
+        AppLogger.shared.networkRequest("BalanceRecordRepository.getMonthlyExpenses")
         FlutterEngineManager.shared.channel?.invokeMethod("getMonthlyExpenses", arguments: nil) { result in
-
             if let expenses = result as? Int {
+                AppLogger.shared.networkSuccess("BalanceRecordRepository.getMonthlyExpenses")
                 onSuccess(expenses)
             } else if let error = result as? FlutterError {
-                print("Error: \(error.message ?? "Unknown error")")
+                AppLogger.shared.networkFailure("BalanceRecordRepository.getMonthlyExpenses", error: error.message ?? "Unknown error")
                 onFailure()
             } else {
-                print("failed getMonthlyExpenses")
+                AppLogger.shared.networkFailure("BalanceRecordRepository.getMonthlyExpenses", error: "Unexpected result type")
                 onFailure()
             }
         }
@@ -84,16 +88,17 @@ class BalanceRecordRepository: BalanceRecordRepositoryProtocol {
     func getDailyBalanceData(year: Int, month: Int,
                              onSuccess: @escaping (([[String: Any]]) -> Void),
                              onFailure: @escaping (() -> Void)) {
+        AppLogger.shared.networkRequest("BalanceRecordRepository.getDailyBalanceData")
         let arguments: [String: Any] = ["year": year, "month": month]
         FlutterEngineManager.shared.channel?.invokeMethod("getDailyBalanceData", arguments: arguments) { result in
-
             if let data = result as? [[String: Any]] {
+                AppLogger.shared.networkSuccess("BalanceRecordRepository.getDailyBalanceData")
                 onSuccess(data)
             } else if let error = result as? FlutterError {
-                print("Error: \(error.message ?? "Unknown error")")
+                AppLogger.shared.networkFailure("BalanceRecordRepository.getDailyBalanceData", error: error.message ?? "Unknown error")
                 onFailure()
             } else {
-                print("failed getDailyBalanceData")
+                AppLogger.shared.networkFailure("BalanceRecordRepository.getDailyBalanceData", error: "Unexpected result type")
                 onFailure()
             }
         }
@@ -101,15 +106,16 @@ class BalanceRecordRepository: BalanceRecordRepositoryProtocol {
 
     func getAvailableYearMonths(onSuccess: @escaping (([String]) -> Void),
                                 onFailure: @escaping (() -> Void)) {
+        AppLogger.shared.networkRequest("BalanceRecordRepository.getAvailableYearMonths")
         FlutterEngineManager.shared.channel?.invokeMethod("getAvailableYearMonths", arguments: nil) { result in
-
             if let yearMonths = result as? [String] {
+                AppLogger.shared.networkSuccess("BalanceRecordRepository.getAvailableYearMonths")
                 onSuccess(yearMonths)
             } else if let error = result as? FlutterError {
-                print("Error: \(error.message ?? "Unknown error")")
+                AppLogger.shared.networkFailure("BalanceRecordRepository.getAvailableYearMonths", error: error.message ?? "Unknown error")
                 onFailure()
             } else {
-                print("failed getAvailableYearMonths")
+                AppLogger.shared.networkFailure("BalanceRecordRepository.getAvailableYearMonths", error: "Unexpected result type")
                 onFailure()
             }
         }

--- a/project/iOS/imitate/Screen/HomeView/GameHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/GameHomeView.swift
@@ -10,6 +10,9 @@ import SwiftUI
 struct GameHomeView: View {
     var body: some View {
         Text("GameHomeView")
+            .onAppear {
+                AppLogger.shared.screenAppeared("GameHomeView")
+            }
     }
 }
 

--- a/project/iOS/imitate/Screen/HomeView/GameHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/GameHomeView.swift
@@ -10,9 +10,7 @@ import SwiftUI
 struct GameHomeView: View {
     var body: some View {
         Text("GameHomeView")
-            .onAppear {
-                AppLogger.shared.screenAppeared("GameHomeView")
-            }
+            .logScreenAppeared()
     }
 }
 

--- a/project/iOS/imitate/Screen/HomeView/HistoryHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/HistoryHomeView.swift
@@ -34,8 +34,8 @@ struct HistoryHomeView: View {
         .cornerRadius(16)
         .shadow(color: .black.opacity(0.1), radius: 8)
         .padding()
+        .logScreenAppeared()
         .onAppear() {
-            AppLogger.shared.screenAppeared("HistoryHomeView")
             viewModel.loadHistory()
         }
     }

--- a/project/iOS/imitate/Screen/HomeView/HistoryHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/HistoryHomeView.swift
@@ -35,6 +35,7 @@ struct HistoryHomeView: View {
         .shadow(color: .black.opacity(0.1), radius: 8)
         .padding()
         .onAppear() {
+            AppLogger.shared.screenAppeared("HistoryHomeView")
             viewModel.loadHistory()
         }
     }

--- a/project/iOS/imitate/Screen/HomeView/InputHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/InputHomeView.swift
@@ -78,6 +78,7 @@ struct InputHomeView: View {
                 }
             }
             .onAppear() {
+                AppLogger.shared.screenAppeared("InputHomeView")
                 selectedIncomeCategory = incomeCategoryList.first ?? ""
                 selectedExpensesCategory = expensesCategoryList.first ?? ""
             }
@@ -111,6 +112,7 @@ struct InputHomeView: View {
     
     /// 入力した情報を判定
     private func validateInputRecode() {
+        AppLogger.shared.buttonTapped("Save", on: "InputHomeView")
         // 金額が存在するか
         if amountText.isEmpty {
             showErrorMessageAlert = true
@@ -139,10 +141,8 @@ struct InputHomeView: View {
                                                                 "createdAt": Date().toString(style: .yyyy_MM_dd),
                                                                 "gameFlag": false])
         // レコード取得
-        BalanceRecordRepository.shared.selectAll(onSuccess: { result in
-            print("success \(String(describing: result?.last))")
+        BalanceRecordRepository.shared.selectAll(onSuccess: { _ in
         }, onFailure: {
-            print("failure")
         })
         dismiss()
     }

--- a/project/iOS/imitate/Screen/HomeView/InputHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/InputHomeView.swift
@@ -112,7 +112,7 @@ struct InputHomeView: View {
     
     /// 入力した情報を判定
     private func validateInputRecode() {
-        AppLogger.shared.buttonTapped("Save", on: "InputHomeView")
+        AppLogger.shared.buttonTapped("Save")
         // 金額が存在するか
         if amountText.isEmpty {
             showErrorMessageAlert = true

--- a/project/iOS/imitate/Screen/HomeView/InputHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/InputHomeView.swift
@@ -112,7 +112,7 @@ struct InputHomeView: View {
     
     /// 入力した情報を判定
     private func validateInputRecode() {
-        AppLogger.shared.buttonTapped("Save")
+        AppLogger.shared.buttonTapped("保存")
         // 金額が存在するか
         if amountText.isEmpty {
             showErrorMessageAlert = true

--- a/project/iOS/imitate/Screen/HomeView/InputHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/InputHomeView.swift
@@ -77,8 +77,8 @@ struct InputHomeView: View {
                         )
                 }
             }
+            .logScreenAppeared()
             .onAppear() {
-                AppLogger.shared.screenAppeared("InputHomeView")
                 selectedIncomeCategory = incomeCategoryList.first ?? ""
                 selectedExpensesCategory = expensesCategoryList.first ?? ""
             }

--- a/project/iOS/imitate/Screen/HomeView/InputHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/InputHomeView.swift
@@ -12,6 +12,7 @@ struct InputHomeView: View {
     @Environment(\.dismiss) private var dismiss
     
     @State private var showErrorMessageAlert = false
+    @State private var isManualDismiss = false
     
     /// 種類カテゴリ(収入・支出) の選択状態
     @State var segmentSelected: InputBalanceSegmentView.BalanceType = .income
@@ -90,11 +91,19 @@ struct InputHomeView: View {
             )
             .padding()
         }
+        .onDisappear {
+            if !isManualDismiss {
+                AppLogger.shared.userAction("スワイプで閉じる")
+            }
+            isManualDismiss = false
+        }
         .alert("金額を入力してください" ,isPresented: $showErrorMessageAlert) {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button {
+                    AppLogger.shared.userAction("閉じる")
+                    isManualDismiss = true
                     dismiss()
                 } label: {
                     Image(systemName: "chevron.left")
@@ -112,7 +121,7 @@ struct InputHomeView: View {
     
     /// 入力した情報を判定
     private func validateInputRecode() {
-        AppLogger.shared.buttonTapped("保存")
+        AppLogger.shared.userAction("保存")
         // 金額が存在するか
         if amountText.isEmpty {
             showErrorMessageAlert = true
@@ -144,6 +153,7 @@ struct InputHomeView: View {
         BalanceRecordRepository.shared.selectAll(onSuccess: { _ in
         }, onFailure: {
         })
+        isManualDismiss = true
         dismiss()
     }
 }

--- a/project/iOS/imitate/Screen/HomeView/SettingHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/SettingHomeView.swift
@@ -10,9 +10,7 @@ import SwiftUI
 struct SettingHomeView: View {
     var body: some View {
         Text("SettingHomeView")
-            .onAppear {
-                AppLogger.shared.screenAppeared("SettingHomeView")
-            }
+            .logScreenAppeared()
     }
 }
 

--- a/project/iOS/imitate/Screen/HomeView/SettingHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/SettingHomeView.swift
@@ -10,6 +10,9 @@ import SwiftUI
 struct SettingHomeView: View {
     var body: some View {
         Text("SettingHomeView")
+            .onAppear {
+                AppLogger.shared.screenAppeared("SettingHomeView")
+            }
     }
 }
 

--- a/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
@@ -23,15 +23,15 @@ struct TopHomeView: View {
                         month: viewModel.selectedMonth,
                         dailyBalances: viewModel.dailyBalances,
                         onPreviousMonth: {
-                            AppLogger.shared.buttonTapped("PreviousMonth", on: "TopHomeView")
+                            AppLogger.shared.buttonTapped("PreviousMonth")
                             viewModel.goToPreviousMonth()
                         },
                         onNextMonth: {
-                            AppLogger.shared.buttonTapped("NextMonth", on: "TopHomeView")
+                            AppLogger.shared.buttonTapped("NextMonth")
                             viewModel.goToNextMonth()
                         },
                         onSelectYearMonth: { year, month in
-                            AppLogger.shared.buttonTapped("SelectYearMonth", on: "TopHomeView")
+                            AppLogger.shared.buttonTapped("SelectYearMonth")
                             viewModel.selectYearMonth(year: year, month: month)
                         },
                         availableYearMonths: viewModel.availableYearMonths
@@ -81,7 +81,7 @@ struct TopHomeView: View {
     }
     
     func tapPlusButton() {
-        AppLogger.shared.buttonTapped("Plus", on: "TopHomeView")
+        AppLogger.shared.buttonTapped("Plus")
         showingSheetToInputHome = true
     }
 }

--- a/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
@@ -22,9 +22,18 @@ struct TopHomeView: View {
                         year: viewModel.selectedYear,
                         month: viewModel.selectedMonth,
                         dailyBalances: viewModel.dailyBalances,
-                        onPreviousMonth: { viewModel.goToPreviousMonth() },
-                        onNextMonth: { viewModel.goToNextMonth() },
-                        onSelectYearMonth: { year, month in viewModel.selectYearMonth(year: year, month: month) },
+                        onPreviousMonth: {
+                            AppLogger.shared.buttonTapped("PreviousMonth", on: "TopHomeView")
+                            viewModel.goToPreviousMonth()
+                        },
+                        onNextMonth: {
+                            AppLogger.shared.buttonTapped("NextMonth", on: "TopHomeView")
+                            viewModel.goToNextMonth()
+                        },
+                        onSelectYearMonth: { year, month in
+                            AppLogger.shared.buttonTapped("SelectYearMonth", on: "TopHomeView")
+                            viewModel.selectYearMonth(year: year, month: month)
+                        },
                         availableYearMonths: viewModel.availableYearMonths
                     )
                     .padding(.vertical, 8)
@@ -58,6 +67,7 @@ struct TopHomeView: View {
             .presentationDetents([.fraction(0.75), .large])
         }
         .onAppear {
+            AppLogger.shared.screenAppeared("TopHomeView")
             viewModel.loadMonthlyBalance()
             viewModel.loadDailyBalances(year: viewModel.selectedYear, month: viewModel.selectedMonth)
             viewModel.loadAvailableYearMonths()
@@ -71,6 +81,7 @@ struct TopHomeView: View {
     }
     
     func tapPlusButton() {
+        AppLogger.shared.buttonTapped("Plus", on: "TopHomeView")
         showingSheetToInputHome = true
     }
 }

--- a/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
@@ -23,15 +23,15 @@ struct TopHomeView: View {
                         month: viewModel.selectedMonth,
                         dailyBalances: viewModel.dailyBalances,
                         onPreviousMonth: {
-                            AppLogger.shared.buttonTapped("PreviousMonth")
+                            AppLogger.shared.buttonTapped("前月")
                             viewModel.goToPreviousMonth()
                         },
                         onNextMonth: {
-                            AppLogger.shared.buttonTapped("NextMonth")
+                            AppLogger.shared.buttonTapped("次月")
                             viewModel.goToNextMonth()
                         },
                         onSelectYearMonth: { year, month in
-                            AppLogger.shared.buttonTapped("SelectYearMonth")
+                            AppLogger.shared.buttonTapped("年月選択")
                             viewModel.selectYearMonth(year: year, month: month)
                         },
                         availableYearMonths: viewModel.availableYearMonths
@@ -81,7 +81,7 @@ struct TopHomeView: View {
     }
     
     func tapPlusButton() {
-        AppLogger.shared.buttonTapped("Plus")
+        AppLogger.shared.buttonTapped("収支入力")
         showingSheetToInputHome = true
     }
 }

--- a/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
@@ -23,15 +23,15 @@ struct TopHomeView: View {
                         month: viewModel.selectedMonth,
                         dailyBalances: viewModel.dailyBalances,
                         onPreviousMonth: {
-                            AppLogger.shared.buttonTapped("前月")
+                            AppLogger.shared.userAction("前月")
                             viewModel.goToPreviousMonth()
                         },
                         onNextMonth: {
-                            AppLogger.shared.buttonTapped("次月")
+                            AppLogger.shared.userAction("次月")
                             viewModel.goToNextMonth()
                         },
                         onSelectYearMonth: { year, month in
-                            AppLogger.shared.buttonTapped("年月選択")
+                            AppLogger.shared.userAction("年月選択")
                             viewModel.selectYearMonth(year: year, month: month)
                         },
                         availableYearMonths: viewModel.availableYearMonths
@@ -81,7 +81,7 @@ struct TopHomeView: View {
     }
     
     func tapPlusButton() {
-        AppLogger.shared.buttonTapped("収支入力")
+        AppLogger.shared.userAction("収支入力")
         showingSheetToInputHome = true
     }
 }

--- a/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/TopHomeView.swift
@@ -66,8 +66,8 @@ struct TopHomeView: View {
             }
             .presentationDetents([.fraction(0.75), .large])
         }
+        .logScreenAppeared()
         .onAppear {
-            AppLogger.shared.screenAppeared("TopHomeView")
             viewModel.loadMonthlyBalance()
             viewModel.loadDailyBalances(year: viewModel.selectedYear, month: viewModel.selectedMonth)
             viewModel.loadAvailableYearMonths()


### PR DESCRIPTION
## Summary

- `AppLogger.swift` を新規追加（os.Logger使用・将来のFirebase対応のための `LogDestination` プロトコル）
- `ViewExtension.swift` を新規追加（`.logScreenAppeared()` カスタムモディファイア）
- Repository層に通信ログ（request / success / failure）を追加
- Screen層に画面表示ログ・ユーザーアクションログを追加
- ユーザーアクションログは明示的に `AppLogger.shared.userAction()` で呼び出す設計
- 全ログの先頭に `【iOS】` プレフィックスを付与しFlutter側と区別
- `#fileID` をデフォルト引数に使用し、呼び出し元のファイル名を自動取得

## Test plan

- [ ] Xcodeデバッグコンソールで各ログが出力されることを確認
  - [ ] 画面表示時に `【iOS】[...] appeared` が出力される
  - [ ] ボタン押下時に `【iOS】[...] action` が出力される
  - [ ] 通信時に `【iOS】[BalanceRecordRepository.xxx] requesting / success / failure` が出力される
  - [ ] InputHomeView をスワイプで閉じた時に `スワイプで閉じる action` が出力される

🤖 Generated with [Claude Code](https://claude.com/claude-code)