### PR TITLE
【Android】AppLogger追加とBalanceRecordRepositoryのログ統合

### DIFF
--- a/project/Android/app/build.gradle.kts
+++ b/project/Android/app/build.gradle.kts
@@ -36,6 +36,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 

--- a/project/Android/app/src/main/java/com/example/imitate_android/BalanceRecordRepository.kt
+++ b/project/Android/app/src/main/java/com/example/imitate_android/BalanceRecordRepository.kt
@@ -1,68 +1,188 @@
 package com.example.imitate_android
 
+import com.example.imitate_android.manager.AppLogger
 import io.flutter.plugin.common.MethodChannel
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
 object BalanceRecordRepository {
+
     suspend fun selectAll(): List<Map<String, Any>> = suspendCoroutine { continuation ->
+        val method = "BalanceRecordRepository.selectAll"
+        AppLogger.channelRequest(method)
         FlutterEngineManager.methodChannel?.invokeMethod("selectAll", null, object : MethodChannel.Result {
             override fun success(result: Any?) {
-                println("result = $result")
-
-                if(result is List<*>) {
+                if (result is List<*>) {
                     try {
-                        // 型変換
-                        val typedList = result.map { item ->
-                            @Suppress("UNCHECKED_CAST")
-                            item as Map<String, Any>
-                        }
+                        @Suppress("UNCHECKED_CAST")
+                        val typedList = result.map { it as Map<String, Any> }
+                        AppLogger.channelSuccess(method)
                         continuation.resume(typedList)
                     } catch (e: ClassCastException) {
+                        AppLogger.channelFailure(method, e.message ?: "ClassCastException")
                         continuation.resumeWithException(e)
                     }
                 } else {
-                    continuation.resumeWithException(
-                        IllegalArgumentException("Expected List<Map<String, Any>>, but got: ${result?.javaClass}")
-                    )
+                    val error = "Expected List<Map<String, Any>>, but got: ${result?.javaClass}"
+                    AppLogger.channelFailure(method, error)
+                    continuation.resumeWithException(IllegalArgumentException(error))
                 }
             }
 
-            override fun error(
-                errorCode: String,
-                errorMessage: String?,
-                errorDetails: Any?
-            ) {
-                println("Error")
+            override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+                AppLogger.channelFailure(method, "$errorCode: $errorMessage")
+                continuation.resumeWithException(Exception("$errorCode: $errorMessage"))
             }
 
             override fun notImplemented() {
-                println("notImplemented")
+                AppLogger.channelFailure(method, "notImplemented")
+                continuation.resumeWithException(UnsupportedOperationException("notImplemented"))
             }
         })
     }
-
 
     suspend fun insert(argument: Map<String, Any>) = suspendCoroutine { continuation ->
+        val method = "BalanceRecordRepository.insert"
+        AppLogger.channelRequest(method)
         FlutterEngineManager.methodChannel?.invokeMethod("insert", argument, object : MethodChannel.Result {
             override fun success(result: Any?) {
-                println("result = $result")
-                continuation.resume(null)
+                AppLogger.channelSuccess(method)
+                continuation.resume(Unit)
             }
 
-            override fun error(
-                errorCode: String,
-                errorMessage: String?,
-                errorDetails: Any?
-            ) {
-                println("Error")
+            override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+                AppLogger.channelFailure(method, "$errorCode: $errorMessage")
+                continuation.resumeWithException(Exception("$errorCode: $errorMessage"))
             }
 
             override fun notImplemented() {
-                println("notImplemented")
+                AppLogger.channelFailure(method, "notImplemented")
+                continuation.resumeWithException(UnsupportedOperationException("notImplemented"))
             }
         })
     }
 
+    suspend fun getMonthlyIncome(): Int = suspendCoroutine { continuation ->
+        val method = "BalanceRecordRepository.getMonthlyIncome"
+        AppLogger.channelRequest(method)
+        FlutterEngineManager.methodChannel?.invokeMethod("getMonthlyIncome", null, object : MethodChannel.Result {
+            override fun success(result: Any?) {
+                if (result is Int) {
+                    AppLogger.channelSuccess(method)
+                    continuation.resume(result)
+                } else {
+                    val error = "Expected Int, but got: ${result?.javaClass}"
+                    AppLogger.channelFailure(method, error)
+                    continuation.resumeWithException(IllegalArgumentException(error))
+                }
+            }
+
+            override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+                AppLogger.channelFailure(method, "$errorCode: $errorMessage")
+                continuation.resumeWithException(Exception("$errorCode: $errorMessage"))
+            }
+
+            override fun notImplemented() {
+                AppLogger.channelFailure(method, "notImplemented")
+                continuation.resumeWithException(UnsupportedOperationException("notImplemented"))
+            }
+        })
+    }
+
+    suspend fun getMonthlyExpenses(): Int = suspendCoroutine { continuation ->
+        val method = "BalanceRecordRepository.getMonthlyExpenses"
+        AppLogger.channelRequest(method)
+        FlutterEngineManager.methodChannel?.invokeMethod("getMonthlyExpenses", null, object : MethodChannel.Result {
+            override fun success(result: Any?) {
+                if (result is Int) {
+                    AppLogger.channelSuccess(method)
+                    continuation.resume(result)
+                } else {
+                    val error = "Expected Int, but got: ${result?.javaClass}"
+                    AppLogger.channelFailure(method, error)
+                    continuation.resumeWithException(IllegalArgumentException(error))
+                }
+            }
+
+            override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+                AppLogger.channelFailure(method, "$errorCode: $errorMessage")
+                continuation.resumeWithException(Exception("$errorCode: $errorMessage"))
+            }
+
+            override fun notImplemented() {
+                AppLogger.channelFailure(method, "notImplemented")
+                continuation.resumeWithException(UnsupportedOperationException("notImplemented"))
+            }
+        })
+    }
+
+    suspend fun getDailyBalanceData(year: Int, month: Int): List<Map<String, Any>> = suspendCoroutine { continuation ->
+        val method = "BalanceRecordRepository.getDailyBalanceData"
+        AppLogger.channelRequest(method)
+        val arguments = mapOf("year" to year, "month" to month)
+        FlutterEngineManager.methodChannel?.invokeMethod("getDailyBalanceData", arguments, object : MethodChannel.Result {
+            override fun success(result: Any?) {
+                if (result is List<*>) {
+                    try {
+                        @Suppress("UNCHECKED_CAST")
+                        val typedList = result.map { it as Map<String, Any> }
+                        AppLogger.channelSuccess(method)
+                        continuation.resume(typedList)
+                    } catch (e: ClassCastException) {
+                        AppLogger.channelFailure(method, e.message ?: "ClassCastException")
+                        continuation.resumeWithException(e)
+                    }
+                } else {
+                    val error = "Expected List<Map<String, Any>>, but got: ${result?.javaClass}"
+                    AppLogger.channelFailure(method, error)
+                    continuation.resumeWithException(IllegalArgumentException(error))
+                }
+            }
+
+            override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+                AppLogger.channelFailure(method, "$errorCode: $errorMessage")
+                continuation.resumeWithException(Exception("$errorCode: $errorMessage"))
+            }
+
+            override fun notImplemented() {
+                AppLogger.channelFailure(method, "notImplemented")
+                continuation.resumeWithException(UnsupportedOperationException("notImplemented"))
+            }
+        })
+    }
+
+    suspend fun getAvailableYearMonths(): List<String> = suspendCoroutine { continuation ->
+        val method = "BalanceRecordRepository.getAvailableYearMonths"
+        AppLogger.channelRequest(method)
+        FlutterEngineManager.methodChannel?.invokeMethod("getAvailableYearMonths", null, object : MethodChannel.Result {
+            override fun success(result: Any?) {
+                if (result is List<*>) {
+                    try {
+                        @Suppress("UNCHECKED_CAST")
+                        val typedList = result.map { it as String }
+                        AppLogger.channelSuccess(method)
+                        continuation.resume(typedList)
+                    } catch (e: ClassCastException) {
+                        AppLogger.channelFailure(method, e.message ?: "ClassCastException")
+                        continuation.resumeWithException(e)
+                    }
+                } else {
+                    val error = "Expected List<String>, but got: ${result?.javaClass}"
+                    AppLogger.channelFailure(method, error)
+                    continuation.resumeWithException(IllegalArgumentException(error))
+                }
+            }
+
+            override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+                AppLogger.channelFailure(method, "$errorCode: $errorMessage")
+                continuation.resumeWithException(Exception("$errorCode: $errorMessage"))
+            }
+
+            override fun notImplemented() {
+                AppLogger.channelFailure(method, "notImplemented")
+                continuation.resumeWithException(UnsupportedOperationException("notImplemented"))
+            }
+        })
+    }
 }

--- a/project/Android/app/src/main/java/com/example/imitate_android/manager/AppLogger.kt
+++ b/project/Android/app/src/main/java/com/example/imitate_android/manager/AppLogger.kt
@@ -1,0 +1,72 @@
+package com.example.imitate_android.manager
+
+import android.util.Log
+import com.example.imitate_android.BuildConfig
+
+interface LogDestination {
+    fun log(level: AppLogger.Level, category: AppLogger.Category, message: String)
+}
+
+object AppLogger {
+
+    enum class Level {
+        DEBUG, INFO, WARNING, ERROR
+    }
+
+    enum class Category(val tag: String) {
+        SCREEN("Screen"),
+        ACTION("Action"),
+        CHANNEL("Channel")
+    }
+
+    var destinations: MutableList<LogDestination> = mutableListOf()
+
+    // MARK: - Screen
+
+    fun screenAppeared(screen: String) {
+        val message = "【Android】[$screen] appeared"
+        debugLog(Category.SCREEN, message)
+        forward(Level.DEBUG, Category.SCREEN, message)
+    }
+
+    // MARK: - Action
+
+    fun userAction(action: String, screen: String) {
+        val message = "【Android】[$screen] '$action' action"
+        debugLog(Category.ACTION, message)
+        forward(Level.DEBUG, Category.ACTION, message)
+    }
+
+    // MARK: - Channel
+
+    fun channelRequest(method: String) {
+        val message = "【Android】[$method] channel requesting"
+        debugLog(Category.CHANNEL, message)
+        forward(Level.DEBUG, Category.CHANNEL, message)
+    }
+
+    fun channelSuccess(method: String) {
+        val message = "【Android】[$method] channel success"
+        debugLog(Category.CHANNEL, message)
+        forward(Level.DEBUG, Category.CHANNEL, message)
+    }
+
+    fun channelFailure(method: String, error: String) {
+        val message = "【Android】[$method] channel failure: $error"
+        debugLog(Category.CHANNEL, message)
+        forward(Level.DEBUG, Category.CHANNEL, message)
+    }
+
+    // MARK: - Private
+
+    private fun debugLog(category: Category, message: String) {
+        if (BuildConfig.DEBUG) {
+            Log.d(category.tag, message)
+        }
+    }
+
+    // TODO: Firebase導入時に FirebaseLogDestination を実装し destinations に追加する
+    private fun forward(level: Level, category: Category, message: String) {
+        destinations.forEach { it.log(level, category, message) }
+    }
+}


### PR DESCRIPTION
## 概要

iOS版に合わせてAndroidにもログ出力機構を導入し、`BalanceRecordRepository` をiOS実装と揃える。

## 変更内容

### 1. AppLogger 追加 (`b944126`)
- `manager/AppLogger.kt` を新規追加
- iOS版 `AppLogger.swift` と同じ構成（Screen/Action/Channel カテゴリ、`LogDestination` インターフェース）
- `BuildConfig.DEBUG` ガードによりリリースビルドでは Logcat 出力を抑制
- `destinations` は将来の Firebase 連携用にリリースビルドでも動作

### 2. BalanceRecordRepository のログ統合と残メソッド実装 (`7ec4723`)
- 既存の `selectAll` / `insert` に `channelRequest` / `channelSuccess` / `channelFailure` を組み込み
- iOS に揃えて以下4メソッドを追加：
  - `getMonthlyIncome`
  - `getMonthlyExpenses`
  - `getDailyBalanceData(year, month)`
  - `getAvailableYearMonths`
- `error` / `notImplemented` / 型不正を握り潰さず例外として呼び出し元に伝播

## iOS との挙動差分

| 項目 | iOS | Android |
|---|---|---|
| 失敗時のエラー伝播 | `onFailure()` のみ | 例外スロー（CLAUDE.md方針に準拠） |
| Logcat/Console出力 | debug レベル（リリース非表示） | `BuildConfig.DEBUG` ガードで同等 |
| `destinations` への forward | 常時 | 常時 |

## テスト方針

- [ ] Android Studio から実機/エミュレータで起動し、Logcat に `Channel` タグでログが出力されることを確認
- [ ] `selectAll` / `insert` の既存呼び出しが従来通り動作することを確認
- [ ] リリースビルドで `Log.d` 出力が抑制されることを確認（任意）

## 残タスク（別PR想定）

- ViewModel から新規4メソッドを呼び出す実装
- `document/LOGGING.md` の Android 欄を「実装済み」に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)