### PR TITLE
【Flutter/iOS】categoriesテーブルを追加しカテゴリ管理の土台を実装

### DIFF
--- a/project/Flutter/lib/BalanceRecordRepository.dart
+++ b/project/Flutter/lib/BalanceRecordRepository.dart
@@ -1,19 +1,15 @@
 import 'package:flutter/services.dart';
 import 'package:sqflite/sqflite.dart';
-import 'package:path/path.dart';
 import 'package:intl/intl.dart';
+import 'DatabaseProvider.dart';
 
 class BalanceRecordRepository {
   static const platform = MethodChannel('BalanceRecordRepository');
-  Database? db;
+  final DatabaseProvider databaseProvider;
 
-  // DBを取得
-  Future<Database> get database async {
-    if (db != null) return db!;
+  BalanceRecordRepository(this.databaseProvider);
 
-    db = await openDB();
-    return db!;
-  }
+  Future<Database> get database => databaseProvider.database;
 
   void registerMethodHandler() {
     platform.setMethodCallHandler((call) async {
@@ -51,32 +47,6 @@ class BalanceRecordRepository {
     });
   }
 
-  Future<Database> openDB() async {
-    print('openDB');
-    final dbPath = await getDatabasesPath();
-    final path = join(dbPath, 'Balance.db');
-
-    return openDatabase(
-      path,
-      version: 1,
-      onCreate: (db, version) async {
-        await db.execute('''
-        CREATE TABLE balanceRecords (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        type TEXT,
-        income_category TEXT,
-        expense_category TEXT,
-        amount INTEGER,
-        memo TEXT,
-        date TEXT,
-        created_at TEXT,
-        game_flag INTEGER
-        );
-      ''');
-      },
-    );
-  }
-
   Future<void> insert(Map<String, dynamic> args) async {
     print('insert: $args');
     final db = await database;
@@ -85,8 +55,8 @@ class BalanceRecordRepository {
         'balanceRecords',
         {
           'type': args['type'],
-          'income_category': args['incomeCategory'],
-          'expense_category': args['expenseCategory'],
+          'income_category_id': args['incomeCategoryId'],
+          'expense_category_id': args['expenseCategoryId'],
           'amount': args['amount'],
           'memo': args['memo'],
           'date': args['date'],
@@ -104,8 +74,23 @@ class BalanceRecordRepository {
   Future<List<Map<String, dynamic>>> selectAll() async {
     print('selectAll');
     final db = await database;
-    // print(await db.rawQuery('SELECT COUNT(*) FROM balanceRecords'));
-    return await db.query('balanceRecords');
+    return await db.rawQuery('''
+      SELECT
+        b.id,
+        b.type,
+        b.income_category_id,
+        b.expense_category_id,
+        ic.name AS income_category,
+        ec.name AS expense_category,
+        b.amount,
+        b.memo,
+        b.date,
+        b.created_at,
+        b.game_flag
+      FROM balanceRecords b
+      LEFT JOIN categories ic ON b.income_category_id = ic.id
+      LEFT JOIN categories ec ON b.expense_category_id = ec.id
+    ''');
   }
 
   Future<int> getMonthlyIncome() async {

--- a/project/Flutter/lib/CategoryRepository.dart
+++ b/project/Flutter/lib/CategoryRepository.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/services.dart';
+import 'package:sqflite/sqflite.dart';
+import 'DatabaseProvider.dart';
+
+class CategoryRepository {
+  static const platform = MethodChannel('CategoryRepository');
+  final DatabaseProvider databaseProvider;
+
+  CategoryRepository(this.databaseProvider);
+
+  Future<Database> get database => databaseProvider.database;
+
+  void registerMethodHandler() {
+    platform.setMethodCallHandler((call) async {
+      switch (call.method) {
+        case 'getCategories':
+          final args = Map<String, dynamic>.from(call.arguments);
+          final type = args['type'] as String;
+          final list = await getCategories(type);
+          print('dart getCategories result: $list');
+          return list;
+        case 'addCategory':
+          final args = Map<String, dynamic>.from(call.arguments);
+          final id = await addCategory(
+            args['name'] as String,
+            args['type'] as String,
+          );
+          print('dart addCategory id: $id');
+          return id;
+        case 'updateCategory':
+          final args = Map<String, dynamic>.from(call.arguments);
+          final count = await updateCategory(
+            args['id'] as int,
+            args['name'] as String,
+          );
+          print('dart updateCategory count: $count');
+          return count;
+        case 'deleteCategory':
+          final args = Map<String, dynamic>.from(call.arguments);
+          final count = await deleteCategory(args['id'] as int);
+          print('dart deleteCategory count: $count');
+          return count;
+        default:
+          throw PlatformException(code: 'Unimplemented');
+      }
+    });
+  }
+
+  Future<List<Map<String, dynamic>>> getCategories(String type) async {
+    final db = await database;
+    return await db.query(
+      'categories',
+      where: 'type = ? AND is_deleted = 0',
+      whereArgs: [type],
+      orderBy: 'id ASC',
+    );
+  }
+
+  Future<int> addCategory(String name, String type) async {
+    final db = await database;
+    return await db.insert('categories', {
+      'name': name,
+      'type': type,
+      'is_deleted': 0,
+    });
+  }
+
+  Future<int> updateCategory(int id, String name) async {
+    final db = await database;
+    return await db.update(
+      'categories',
+      {'name': name},
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  // 論理削除
+  Future<int> deleteCategory(int id) async {
+    final db = await database;
+    return await db.update(
+      'categories',
+      {'is_deleted': 1},
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+}

--- a/project/Flutter/lib/DatabaseProvider.dart
+++ b/project/Flutter/lib/DatabaseProvider.dart
@@ -1,0 +1,82 @@
+import 'package:sqflite/sqflite.dart';
+import 'package:path/path.dart';
+
+class DatabaseProvider {
+  static const int _databaseVersion = 1;
+  static const String _databaseName = 'Balance.db';
+
+  Database? _db;
+
+  Future<Database> get database async {
+    if (_db != null) return _db!;
+    _db = await _open();
+    return _db!;
+  }
+
+  Future<Database> _open() async {
+    print('openDB');
+    final dbPath = await getDatabasesPath();
+    final path = join(dbPath, _databaseName);
+
+    return openDatabase(
+      path,
+      version: _databaseVersion,
+      onCreate: (db, version) async {
+        await _createTables(db);
+        await _seedCategories(db);
+      },
+      onUpgrade: (db, oldVersion, newVersion) async {
+        // 開発中のためテーブルを作り直す
+        await db.execute('DROP TABLE IF EXISTS balanceRecords');
+        await db.execute('DROP TABLE IF EXISTS categories');
+        await _createTables(db);
+        await _seedCategories(db);
+      },
+    );
+  }
+
+  Future<void> _createTables(Database db) async {
+    await db.execute('''
+      CREATE TABLE categories (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL,
+        is_deleted INTEGER NOT NULL DEFAULT 0
+      );
+    ''');
+
+    await db.execute('''
+      CREATE TABLE balanceRecords (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        type TEXT,
+        income_category_id INTEGER,
+        expense_category_id INTEGER,
+        amount INTEGER,
+        memo TEXT,
+        date TEXT,
+        created_at TEXT,
+        game_flag INTEGER
+      );
+    ''');
+  }
+
+  Future<void> _seedCategories(Database db) async {
+    const incomeNames = ['給料', 'その他'];
+    const expenseNames = ['食費', '外食費', '日用品', '交通費', '衣服', '趣味', 'その他'];
+
+    for (final name in incomeNames) {
+      await db.insert('categories', {
+        'name': name,
+        'type': 'income',
+        'is_deleted': 0,
+      });
+    }
+    for (final name in expenseNames) {
+      await db.insert('categories', {
+        'name': name,
+        'type': 'expense',
+        'is_deleted': 0,
+      });
+    }
+  }
+}

--- a/project/Flutter/lib/main.dart
+++ b/project/Flutter/lib/main.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'DatabaseProvider.dart';
 import 'BalanceRecordRepository.dart';
+import 'CategoryRepository.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  final BalanceRecordRepository repo = BalanceRecordRepository();
-  repo.registerMethodHandler();
+  final databaseProvider = DatabaseProvider();
+  final balanceRecordRepository = BalanceRecordRepository(databaseProvider);
+  balanceRecordRepository.registerMethodHandler();
+  final categoryRepository = CategoryRepository(databaseProvider);
+  categoryRepository.registerMethodHandler();
 }
 
 class MyHomePage extends StatefulWidget {

--- a/project/iOS/imitate.xcodeproj/project.pbxproj
+++ b/project/iOS/imitate.xcodeproj/project.pbxproj
@@ -32,6 +32,18 @@
 		B961A26C2F09A37900B2989C /* InputBalanceCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B961A2692F09A37900B2989C /* InputBalanceCategoryView.swift */; };
 		B96CBAAB2E51BF3A00DB2E48 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96CBAAA2E51BF3A00DB2E48 /* AppDelegate.swift */; };
 		B96CBAAF2E51BF7800DB2E48 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96CBAAE2E51BF7800DB2E48 /* SceneDelegate.swift */; };
+		B99ABA6D2FA1DEA3000E2A10 /* CategoryInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA6C2FA1DEA3000E2A10 /* CategoryInfo.swift */; };
+		B99ABA6E2FA1DEA3000E2A10 /* CategoryInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA6C2FA1DEA3000E2A10 /* CategoryInfo.swift */; };
+		B99ABA6F2FA1DEA3000E2A10 /* CategoryInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA6C2FA1DEA3000E2A10 /* CategoryInfo.swift */; };
+		B99ABA712FA1DEB6000E2A10 /* CategoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA702FA1DEB6000E2A10 /* CategoryRepository.swift */; };
+		B99ABA722FA1DEB6000E2A10 /* CategoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA702FA1DEB6000E2A10 /* CategoryRepository.swift */; };
+		B99ABA732FA1DEB6000E2A10 /* CategoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA702FA1DEB6000E2A10 /* CategoryRepository.swift */; };
+		B9AB12352F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
+		B9AB12362F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
+		B9AB12372F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
+		B9AB12392F9C000000000002 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12382F9C000000000002 /* ViewExtension.swift */; };
+		B9AB123A2F9C000000000002 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12382F9C000000000002 /* ViewExtension.swift */; };
+		B9AB123B2F9C000000000002 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12382F9C000000000002 /* ViewExtension.swift */; };
 		B9B00CD02E518DED00BCB306 /* imitateApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B00CCF2E518DED00BCB306 /* imitateApp.swift */; };
 		B9B00CD22E518DED00BCB306 /* LaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B00CD12E518DED00BCB306 /* LaunchView.swift */; };
 		B9B00CD42E518DEE00BCB306 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B9B00CD32E518DEE00BCB306 /* Assets.xcassets */; };
@@ -73,12 +85,12 @@
 		B9C191CA2EFFF4C500AFE3C3 /* BalanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191C92EFFF4C500AFE3C3 /* BalanceView.swift */; };
 		B9C191CB2EFFF4C500AFE3C3 /* BalanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191C92EFFF4C500AFE3C3 /* BalanceView.swift */; };
 		B9C191CC2EFFF4C500AFE3C3 /* BalanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191C92EFFF4C500AFE3C3 /* BalanceView.swift */; };
-		B9C191D12F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */; };
-		B9C191D22F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */; };
-		B9C191D32F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */; };
 		B9C191CE2F081E9400AFE3C3 /* BalanceRecordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191CD2F081E9400AFE3C3 /* BalanceRecordRepository.swift */; };
 		B9C191CF2F081E9400AFE3C3 /* BalanceRecordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191CD2F081E9400AFE3C3 /* BalanceRecordRepository.swift */; };
 		B9C191D02F081E9400AFE3C3 /* BalanceRecordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191CD2F081E9400AFE3C3 /* BalanceRecordRepository.swift */; };
+		B9C191D12F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */; };
+		B9C191D22F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */; };
+		B9C191D32F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */; };
 		B9D08D302E520ED20074BFD5 /* FlutterEngineManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D08D2F2E520ED20074BFD5 /* FlutterEngineManager.swift */; };
 		B9DEC5572F1BF4AC0085FEC5 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DEC5562F1BF4AC0085FEC5 /* DateExtension.swift */; };
 		B9DEC55A2F1D525C0085FEC5 /* HistoryRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DEC5592F1D525C0085FEC5 /* HistoryRowView.swift */; };
@@ -89,12 +101,6 @@
 		B9E0D79A2F85344B00CF247C /* DictionaryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E0D7992F85344B00CF247C /* DictionaryExtension.swift */; };
 		B9E0D79B2F85344B00CF247C /* DictionaryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E0D7992F85344B00CF247C /* DictionaryExtension.swift */; };
 		B9E0D79C2F85344B00CF247C /* DictionaryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E0D7992F85344B00CF247C /* DictionaryExtension.swift */; };
-		B9AB12352F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
-		B9AB12362F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
-		B9AB12372F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
-		B9AB12392F9C000000000002 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12382F9C000000000002 /* ViewExtension.swift */; };
-		B9AB123A2F9C000000000002 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12382F9C000000000002 /* ViewExtension.swift */; };
-		B9AB123B2F9C000000000002 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12382F9C000000000002 /* ViewExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -143,6 +149,10 @@
 		B961A2692F09A37900B2989C /* InputBalanceCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBalanceCategoryView.swift; sourceTree = "<group>"; };
 		B96CBAAA2E51BF3A00DB2E48 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B96CBAAE2E51BF7800DB2E48 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		B99ABA6C2FA1DEA3000E2A10 /* CategoryInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryInfo.swift; sourceTree = "<group>"; };
+		B99ABA702FA1DEB6000E2A10 /* CategoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRepository.swift; sourceTree = "<group>"; };
+		B9AB12342F9C000000000001 /* AppLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogger.swift; sourceTree = "<group>"; };
+		B9AB12382F9C000000000002 /* ViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
 		B9B00CCC2E518DED00BCB306 /* imitate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = imitate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9B00CCF2E518DED00BCB306 /* imitateApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = imitateApp.swift; sourceTree = "<group>"; };
 		B9B00CD12E518DED00BCB306 /* LaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchView.swift; sourceTree = "<group>"; };
@@ -161,11 +171,9 @@
 		B9C191C02EFFDE4E00AFE3C3 /* HistoryHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHomeView.swift; sourceTree = "<group>"; };
 		B9C191C42EFFDE6400AFE3C3 /* SettingHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingHomeView.swift; sourceTree = "<group>"; };
 		B9C191C92EFFF4C500AFE3C3 /* BalanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceView.swift; sourceTree = "<group>"; };
-		B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceGraphView.swift; sourceTree = "<group>"; };
 		B9C191CD2F081E9400AFE3C3 /* BalanceRecordRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceRecordRepository.swift; sourceTree = "<group>"; };
+		B9C191D02F0A000000AFE3C3 /* BalanceGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceGraphView.swift; sourceTree = "<group>"; };
 		B9D08D2F2E520ED20074BFD5 /* FlutterEngineManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterEngineManager.swift; sourceTree = "<group>"; };
-		B9AB12342F9C000000000001 /* AppLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogger.swift; sourceTree = "<group>"; };
-		B9AB12382F9C000000000002 /* ViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
 		B9DEC5562F1BF4AC0085FEC5 /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		B9DEC5592F1D525C0085FEC5 /* HistoryRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryRowView.swift; sourceTree = "<group>"; };
 		B9E0D7992F85344B00CF247C /* DictionaryExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtension.swift; sourceTree = "<group>"; };
@@ -367,6 +375,7 @@
 			isa = PBXGroup;
 			children = (
 				B9C191CD2F081E9400AFE3C3 /* BalanceRecordRepository.swift */,
+				B99ABA702FA1DEB6000E2A10 /* CategoryRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -385,6 +394,7 @@
 			isa = PBXGroup;
 			children = (
 				B9C166612F26772400A3BEC5 /* BalanceRecordInfo.swift */,
+				B99ABA6C2FA1DEA3000E2A10 /* CategoryInfo.swift */,
 			);
 			path = Info;
 			sourceTree = "<group>";
@@ -535,8 +545,10 @@
 				B9AB12392F9C000000000002 /* ViewExtension.swift in Sources */,
 				B9C166622F26772400A3BEC5 /* BalanceRecordInfo.swift in Sources */,
 				B9DEC5572F1BF4AC0085FEC5 /* DateExtension.swift in Sources */,
+				B99ABA712FA1DEB6000E2A10 /* CategoryRepository.swift in Sources */,
 				B95E7F5B2F8558C10071D91A /* HistoryHomeViewModel.swift in Sources */,
 				B9B00CD02E518DED00BCB306 /* imitateApp.swift in Sources */,
+				B99ABA6D2FA1DEA3000E2A10 /* CategoryInfo.swift in Sources */,
 				B95E7F5E2F8558C10071D91A /* HistoryInfoMapper.swift in Sources */,
 				B9C191CA2EFFF4C500AFE3C3 /* BalanceView.swift in Sources */,
 				B9C191D12F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */,
@@ -555,6 +567,7 @@
 				B9C191A52EFFDC2100AFE3C3 /* AppDelegate.swift in Sources */,
 				B95E7F5F2F8558C10071D91A /* HistoryInfoMapper.swift in Sources */,
 				B9C191AD2EFFDC3000AFE3C3 /* LaunchView.swift in Sources */,
+				B99ABA722FA1DEB6000E2A10 /* CategoryRepository.swift in Sources */,
 				B961A2662F097AEB00B2989C /* InputBalanceSegmentView.swift in Sources */,
 				B9B00CE12E518DEE00BCB306 /* imitateTests.swift in Sources */,
 				B95E7F672F8558D70071D91A /* HistoryInfoMapperTests.swift in Sources */,
@@ -575,6 +588,7 @@
 				B9C191CF2F081E9400AFE3C3 /* BalanceRecordRepository.swift in Sources */,
 				B9DEC55D2F1D53930085FEC5 /* DateExtension.swift in Sources */,
 				B9C191BA2EFFDDB700AFE3C3 /* InputHomeView.swift in Sources */,
+				B99ABA6E2FA1DEA3000E2A10 /* CategoryInfo.swift in Sources */,
 				B9C191BE2EFFDE3000AFE3C3 /* GameHomeView.swift in Sources */,
 				B95E7F5C2F8558C10071D91A /* HistoryHomeViewModel.swift in Sources */,
 				B9C191C22EFFDE4E00AFE3C3 /* HistoryHomeView.swift in Sources */,
@@ -606,11 +620,13 @@
 				B9E0D79C2F85344B00CF247C /* DictionaryExtension.swift in Sources */,
 				B9C191A62EFFDC2100AFE3C3 /* AppDelegate.swift in Sources */,
 				B9C191D02F081E9400AFE3C3 /* BalanceRecordRepository.swift in Sources */,
+				B99ABA6F2FA1DEA3000E2A10 /* CategoryInfo.swift in Sources */,
 				B9B00CED2E518DEE00BCB306 /* imitateUITestsLaunchTests.swift in Sources */,
 				B9B00CEB2E518DEE00BCB306 /* imitateUITests.swift in Sources */,
 				B9C191C72EFFDE6400AFE3C3 /* SettingHomeView.swift in Sources */,
 				B9C191BF2EFFDE3000AFE3C3 /* GameHomeView.swift in Sources */,
 				B9C166642F267E7600A3BEC5 /* BalanceRecordInfo.swift in Sources */,
+				B99ABA732FA1DEB6000E2A10 /* CategoryRepository.swift in Sources */,
 				B95E7F5D2F8558C10071D91A /* HistoryHomeViewModel.swift in Sources */,
 				B9C191CC2EFFF4C500AFE3C3 /* BalanceView.swift in Sources */,
 				B9C191D32F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */,

--- a/project/iOS/imitate/Manager/FlutterEngineManager.swift
+++ b/project/iOS/imitate/Manager/FlutterEngineManager.swift
@@ -15,18 +15,20 @@ class FlutterEngineManager {
     private(set) var flutterEngine: FlutterEngine?
     
     private(set) var channel: FlutterMethodChannel?
+    private(set) var categoryChannel: FlutterMethodChannel?
 
     func initialize() {
         flutterEngine = FlutterEngine(name: "")
         flutterEngine?.run()
         setChannel()
     }
-    
+
     func setChannel() {
         guard let flutterEngine = flutterEngine else {
             return
         }
         GeneratedPluginRegistrant.register(with: flutterEngine)
         channel = FlutterMethodChannel(name: "BalanceRecordRepository", binaryMessenger: flutterEngine.binaryMessenger)
+        categoryChannel = FlutterMethodChannel(name: "CategoryRepository", binaryMessenger: flutterEngine.binaryMessenger)
     }
 }

--- a/project/iOS/imitate/Model/Info/CategoryInfo.swift
+++ b/project/iOS/imitate/Model/Info/CategoryInfo.swift
@@ -1,0 +1,39 @@
+//
+//  CategoryInfo.swift
+//  imitate
+//
+//  Created by garigari0118 on 2026/04/29.
+//
+
+import Foundation
+
+enum CategoryType: String, Codable {
+    case income = "income"
+    case expense = "expense"
+}
+
+struct CategoryInfo: Codable {
+    /// カテゴリID
+    var id: Int?
+    /// カテゴリ名
+    var name: String?
+    /// 種類
+    var type: CategoryType?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case type
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        id = try values.decodeIfPresent(Int.self, forKey: .id)
+        name = try values.decodeIfPresent(String.self, forKey: .name)
+        type = try values.decodeIfPresent(CategoryType.self, forKey: .type)
+    }
+
+    static func parse(dictionary: [String: Any]) throws -> CategoryInfo? {
+        try dictionary.decode(self)
+    }
+}

--- a/project/iOS/imitate/Model/Repository/CategoryRepository.swift
+++ b/project/iOS/imitate/Model/Repository/CategoryRepository.swift
@@ -1,0 +1,105 @@
+//
+//  CategoryRepository.swift
+//  imitate
+//
+//  Created by garigari0118 on 2026/04/29.
+//
+
+import Flutter
+
+protocol CategoryRepositoryProtocol {
+    func getCategories(type: CategoryType,
+                       onSuccess: @escaping (([CategoryInfo]) -> Void),
+                       onFailure: @escaping (() -> Void))
+    func addCategory(name: String, type: CategoryType,
+                     onSuccess: @escaping ((Int) -> Void),
+                     onFailure: @escaping (() -> Void))
+    func updateCategory(id: Int, name: String,
+                        onSuccess: @escaping (() -> Void),
+                        onFailure: @escaping (() -> Void))
+    func deleteCategory(id: Int,
+                        onSuccess: @escaping (() -> Void),
+                        onFailure: @escaping (() -> Void))
+}
+
+class CategoryRepository: CategoryRepositoryProtocol {
+
+    static let shared = CategoryRepository()
+
+    func getCategories(type: CategoryType,
+                       onSuccess: @escaping (([CategoryInfo]) -> Void),
+                       onFailure: @escaping (() -> Void)) {
+        AppLogger.shared.channelRequest("CategoryRepository.getCategories")
+        let arguments: [String: Any] = ["type": type.rawValue]
+        FlutterEngineManager.shared.categoryChannel?.invokeMethod("getCategories", arguments: arguments) { result in
+            if let list = result as? [[String: Any]] {
+                let categories = list.compactMap { (try? CategoryInfo.parse(dictionary: $0)) ?? nil }
+                AppLogger.shared.channelSuccess("CategoryRepository.getCategories")
+                onSuccess(categories)
+            } else if let error = result as? FlutterError {
+                AppLogger.shared.channelFailure("CategoryRepository.getCategories", error: error.message ?? "Unknown error")
+                onFailure()
+            } else {
+                AppLogger.shared.channelFailure("CategoryRepository.getCategories", error: "Unexpected result type")
+                onFailure()
+            }
+        }
+    }
+
+    func addCategory(name: String, type: CategoryType,
+                     onSuccess: @escaping ((Int) -> Void),
+                     onFailure: @escaping (() -> Void)) {
+        AppLogger.shared.channelRequest("CategoryRepository.addCategory")
+        let arguments: [String: Any] = ["name": name, "type": type.rawValue]
+        FlutterEngineManager.shared.categoryChannel?.invokeMethod("addCategory", arguments: arguments) { result in
+            if let id = result as? Int {
+                AppLogger.shared.channelSuccess("CategoryRepository.addCategory")
+                onSuccess(id)
+            } else if let error = result as? FlutterError {
+                AppLogger.shared.channelFailure("CategoryRepository.addCategory", error: error.message ?? "Unknown error")
+                onFailure()
+            } else {
+                AppLogger.shared.channelFailure("CategoryRepository.addCategory", error: "Unexpected result type")
+                onFailure()
+            }
+        }
+    }
+
+    func updateCategory(id: Int, name: String,
+                        onSuccess: @escaping (() -> Void),
+                        onFailure: @escaping (() -> Void)) {
+        AppLogger.shared.channelRequest("CategoryRepository.updateCategory")
+        let arguments: [String: Any] = ["id": id, "name": name]
+        FlutterEngineManager.shared.categoryChannel?.invokeMethod("updateCategory", arguments: arguments) { result in
+            if result is Int {
+                AppLogger.shared.channelSuccess("CategoryRepository.updateCategory")
+                onSuccess()
+            } else if let error = result as? FlutterError {
+                AppLogger.shared.channelFailure("CategoryRepository.updateCategory", error: error.message ?? "Unknown error")
+                onFailure()
+            } else {
+                AppLogger.shared.channelFailure("CategoryRepository.updateCategory", error: "Unexpected result type")
+                onFailure()
+            }
+        }
+    }
+
+    func deleteCategory(id: Int,
+                        onSuccess: @escaping (() -> Void),
+                        onFailure: @escaping (() -> Void)) {
+        AppLogger.shared.channelRequest("CategoryRepository.deleteCategory")
+        let arguments: [String: Any] = ["id": id]
+        FlutterEngineManager.shared.categoryChannel?.invokeMethod("deleteCategory", arguments: arguments) { result in
+            if result is Int {
+                AppLogger.shared.channelSuccess("CategoryRepository.deleteCategory")
+                onSuccess()
+            } else if let error = result as? FlutterError {
+                AppLogger.shared.channelFailure("CategoryRepository.deleteCategory", error: error.message ?? "Unknown error")
+                onFailure()
+            } else {
+                AppLogger.shared.channelFailure("CategoryRepository.deleteCategory", error: "Unexpected result type")
+                onFailure()
+            }
+        }
+    }
+}

--- a/project/iOS/imitate/Screen/HomeView/InputHome/InputBalanceCategoryView.swift
+++ b/project/iOS/imitate/Screen/HomeView/InputHome/InputBalanceCategoryView.swift
@@ -8,56 +8,49 @@
 import SwiftUI
 
 struct InputBalanceCategoryView: View {
-    
+
     /// 指定してる種類
     @Binding var balanceType: InputBalanceSegmentView.BalanceType
-    /// 指定してる収入カテゴリ名
-    @Binding var selectedIncomeCategory: String
-    /// 指定してる支出カテゴリ名
-    @Binding var selectedExpensesCategory: String
+    /// 選択中の収入カテゴリID
+    @Binding var selectedIncomeCategoryId: Int?
+    /// 選択中の支出カテゴリID
+    @Binding var selectedExpenseCategoryId: Int?
     /// 収入カテゴリ一覧
-    var incomeCategoryList: [String]
+    var incomeCategoryList: [CategoryInfo]
     /// 支出カテゴリ一覧
-    var expensesCategoryList: [String]
-    
+    var expenseCategoryList: [CategoryInfo]
+
     var body: some View {
         HStack(alignment: .center, spacing: 8) {
             Text("カテゴリー")
-            
+
             switch balanceType {
             case .income:
-                Picker(selectedIncomeCategory.isEmpty ? "選択してください" : selectedIncomeCategory, selection: $selectedIncomeCategory) {
-                    if !selectedIncomeCategory.isEmpty {
-                        ForEach(Array(incomeCategoryList.enumerated()), id: \.offset) { _, category in
-                            Text(category).tag(category)
-                        }
-                    }
-                }
-                .pickerStyle(.menu)
-                .frame(maxWidth: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color.gray.opacity(0.4))
+                categoryPicker(
+                    selectedId: $selectedIncomeCategoryId,
+                    categories: incomeCategoryList
                 )
             case .expenses:
-                Picker(selectedExpensesCategory.isEmpty ? "選択してください" : selectedExpensesCategory, selection: $selectedExpensesCategory) {
-                    if !selectedIncomeCategory.isEmpty {
-                        ForEach(Array(expensesCategoryList.enumerated()), id: \.offset) { _, category in
-                            Text(category).tag(category)
-                        }
-                    }
-                }
-                .pickerStyle(.menu)
-                .frame(maxWidth: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color.gray.opacity(0.4))
+                categoryPicker(
+                    selectedId: $selectedExpenseCategoryId,
+                    categories: expenseCategoryList
                 )
             }
         }
     }
-}
 
-//#Preview {
-//    InputBalanceCategoryView()
-//}
+    private func categoryPicker(selectedId: Binding<Int?>, categories: [CategoryInfo]) -> some View {
+        let label = categories.first(where: { $0.id == selectedId.wrappedValue })?.name ?? "選択してください"
+        return Picker(label, selection: selectedId) {
+            ForEach(categories, id: \.id) { category in
+                Text(category.name ?? "").tag(category.id)
+            }
+        }
+        .pickerStyle(.menu)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.gray.opacity(0.4))
+        )
+    }
+}

--- a/project/iOS/imitate/Screen/HomeView/InputHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/InputHomeView.swift
@@ -8,43 +8,39 @@
 import SwiftUI
 
 struct InputHomeView: View {
-    
+
     @Environment(\.dismiss) private var dismiss
-    
+
     @State private var showErrorMessageAlert = false
     @State private var isManualDismiss = false
-    
+
     /// 種類カテゴリ(収入・支出) の選択状態
     @State var segmentSelected: InputBalanceSegmentView.BalanceType = .income
     /// 金額
     @State private var amountText = ""
-    // 選択中のカテゴリ
-    /// 指定してる収入カテゴリ名
-    @State private var selectedIncomeCategory: String = ""
-    /// 指定してる支出カテゴリ名
-    @State private var selectedExpensesCategory: String = ""
-    
-    @State var categoryList = [String]()
-    
-    // TODO: カテゴリ一覧は、flutter側から取得できるようにする
-    /// 収入種類のカテゴリ一覧
-    let incomeCategoryList = ["給料", "その他"]
+
+    /// 収入カテゴリ一覧
+    @State private var incomeCategoryList: [CategoryInfo] = []
     /// 支出カテゴリ一覧
-    let expensesCategoryList = ["食費", "外食費", "日用品", "交通費", "衣服", "交通費", "趣味", "その他"]
-    
+    @State private var expenseCategoryList: [CategoryInfo] = []
+    /// 選択中の収入カテゴリID
+    @State private var selectedIncomeCategoryId: Int? = nil
+    /// 選択中の支出カテゴリID
+    @State private var selectedExpenseCategoryId: Int? = nil
+
     /// 指定している日付情報
     @State private var selectedDate = Date()
-    
+
     /// 入力したメモ文字列
     @State private var memoText = ""
-    
+
     var body: some View {
         ScrollView {
             VStack(spacing: 16) {
-                
+
                 // 種類カテゴリ(収入・支出)
                 InputBalanceSegmentView(selected: $segmentSelected)
-                
+
                 // 金額
                 HStack(alignment: .center, spacing: 16) {
                     Text("金額")
@@ -52,13 +48,16 @@ struct InputHomeView: View {
                         .keyboardType(.numberPad)
                         .textFieldStyle(.roundedBorder)
                 }
-                
+
                 // カテゴリー
-                InputBalanceCategoryView(balanceType: $segmentSelected,
-                                         selectedIncomeCategory: $selectedIncomeCategory,
-                                         selectedExpensesCategory: $selectedExpensesCategory,
-                                         incomeCategoryList: incomeCategoryList,
-                                         expensesCategoryList: expensesCategoryList)
+                InputBalanceCategoryView(
+                    balanceType: $segmentSelected,
+                    selectedIncomeCategoryId: $selectedIncomeCategoryId,
+                    selectedExpenseCategoryId: $selectedExpenseCategoryId,
+                    incomeCategoryList: incomeCategoryList,
+                    expenseCategoryList: expenseCategoryList
+                )
+
                 // 日付
                 DatePicker(
                     "日付",
@@ -66,7 +65,7 @@ struct InputHomeView: View {
                     displayedComponents: .date
                 )
                 .datePickerStyle(.compact)
-                
+
                 VStack(alignment: .leading, spacing: 16) {
                     Text("メモ(任意)")
                     TextEditor(text: $memoText)
@@ -79,9 +78,8 @@ struct InputHomeView: View {
                 }
             }
             .logScreenAppeared()
-            .onAppear() {
-                selectedIncomeCategory = incomeCategoryList.first ?? ""
-                selectedExpensesCategory = expensesCategoryList.first ?? ""
+            .onAppear {
+                fetchCategories()
             }
             .padding()
             .background(
@@ -97,7 +95,7 @@ struct InputHomeView: View {
             }
             isManualDismiss = false
         }
-        .alert("金額を入力してください" ,isPresented: $showErrorMessageAlert) {
+        .alert("金額を入力してください", isPresented: $showErrorMessageAlert) {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
@@ -118,41 +116,64 @@ struct InputHomeView: View {
             }
         }
     }
-    
+
+    /// カテゴリ一覧をFlutterから取得
+    private func fetchCategories() {
+        CategoryRepository.shared.getCategories(type: .income) { categories in
+            incomeCategoryList = categories
+            if selectedIncomeCategoryId == nil {
+                selectedIncomeCategoryId = categories.first.flatMap { $0.id }
+            }
+        } onFailure: {}
+
+        CategoryRepository.shared.getCategories(type: .expense) { categories in
+            expenseCategoryList = categories
+            if selectedExpenseCategoryId == nil {
+                selectedExpenseCategoryId = categories.first.flatMap { $0.id }
+            }
+        } onFailure: {}
+
+    }
+
     /// 入力した情報を判定
     private func validateInputRecode() {
         AppLogger.shared.userAction("保存")
-        // 金額が存在するか
         if amountText.isEmpty {
             showErrorMessageAlert = true
             return
         }
-        // 保存処理
         savaRecode()
     }
-    
+
     /// 入力したレコードを保存
     private func savaRecode() {
-        // 種類カテゴリで選択していないカテゴリ名を空文字にする
+        let incomeCategoryId: Int
+        let expenseCategoryId: Int
+
         switch segmentSelected {
         case .income:
-            selectedExpensesCategory = ""
+            incomeCategoryId = selectedIncomeCategoryId ?? 0
+            expenseCategoryId = 0
         case .expenses:
-            selectedIncomeCategory = ""
+            incomeCategoryId = 0
+            expenseCategoryId = selectedExpenseCategoryId ?? 0
         }
-        // レコード追加
-        BalanceRecordRepository.shared.insertRecord(arguments: ["type": segmentSelected.name,
-                                                                "incomeCategory": selectedIncomeCategory,
-                                                                "expenseCategory": selectedExpensesCategory,
-                                                                "amount": amountText,
-                                                                "memo": memoText,
-                                                                "date": selectedDate.toString(style: .yyyy_MM_dd),
-                                                                "createdAt": Date().toString(style: .yyyy_MM_dd),
-                                                                "gameFlag": false])
-        // レコード取得
+
+        BalanceRecordRepository.shared.insertRecord(arguments: [
+            "type": segmentSelected.name,
+            "incomeCategoryId": incomeCategoryId,
+            "expenseCategoryId": expenseCategoryId,
+            "amount": amountText,
+            "memo": memoText,
+            "date": selectedDate.toString(style: .yyyy_MM_dd),
+            "createdAt": Date().toString(style: .yyyy_MM_dd),
+            "gameFlag": false
+        ])
+
         BalanceRecordRepository.shared.selectAll(onSuccess: { _ in
         }, onFailure: {
         })
+
         isManualDismiss = true
         dismiss()
     }


### PR DESCRIPTION
## Summary
- FlutterのSQLiteに`categories`テーブルを追加し、カテゴリをDBで一元管理できるようにした
- `DatabaseProvider`を新規作成しDB管理をRepositoryから分離
- iOS側の`CategoryRepository`を追加し、カテゴリ一覧のハードコードを廃止してFlutter側から取得する形に移行
- `balanceRecords`のカテゴリカラムをTEXT（文字列）からINTEGER（ID参照）に変更

## 変更内容

### Flutter
- `DatabaseProvider.dart` 新規作成 — DB接続・スキーマ定義・マイグレーション・初期データ投入
- `CategoryRepository.dart` 新規作成 — MethodChannel `CategoryRepository`（getCategories / addCategory / updateCategory / deleteCategory）
- `BalanceRecordRepository.dart` — DB管理をDatabaseProviderに分離、カテゴリカラムをID化、selectAllでcategoriesとJOIN
- `main.dart` — DatabaseProviderを各Repositoryに注入

### iOS
- `CategoryInfo.swift` 新規作成 — Codableモデル（id / name / type）
- `CategoryRepository.swift` 新規作成 — categoryChannelを通じてFlutterのCategoryRepositoryを呼び出す
- `FlutterEngineManager.swift` — `categoryChannel` を追加
- `InputHomeView.swift` — カテゴリ一覧をFlutterから取得、insertRecordをカテゴリIDベースに変更
- `InputBalanceCategoryView.swift` — `[CategoryInfo]`ベースに変更、選択をIDで管理

## Test plan
- [x] iOSアプリ起動時にカテゴリ一覧が表示される
- [x] 収入・支出それぞれのカテゴリが正しく切り替わる
- [x] カテゴリを選択して保存できる
- [x] 履歴画面にカテゴリ名が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)