### PR TITLE
【iOS】カテゴリ管理画面を追加

### DIFF
--- a/project/iOS/imitate.xcodeproj/project.pbxproj
+++ b/project/iOS/imitate.xcodeproj/project.pbxproj
@@ -38,6 +38,12 @@
 		B99ABA712FA1DEB6000E2A10 /* CategoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA702FA1DEB6000E2A10 /* CategoryRepository.swift */; };
 		B99ABA722FA1DEB6000E2A10 /* CategoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA702FA1DEB6000E2A10 /* CategoryRepository.swift */; };
 		B99ABA732FA1DEB6000E2A10 /* CategoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA702FA1DEB6000E2A10 /* CategoryRepository.swift */; };
+		B99ABA762FA1E97A000E2A10 /* CategoryManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA752FA1E97A000E2A10 /* CategoryManagementView.swift */; };
+		B99ABA772FA1E97A000E2A10 /* CategoryManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA752FA1E97A000E2A10 /* CategoryManagementView.swift */; };
+		B99ABA782FA1E97A000E2A10 /* CategoryManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA752FA1E97A000E2A10 /* CategoryManagementView.swift */; };
+		B99ABA7A2FA1E98D000E2A10 /* CategoryManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA792FA1E98D000E2A10 /* CategoryManagementViewModel.swift */; };
+		B99ABA7B2FA1E98D000E2A10 /* CategoryManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA792FA1E98D000E2A10 /* CategoryManagementViewModel.swift */; };
+		B99ABA7C2FA1E98D000E2A10 /* CategoryManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99ABA792FA1E98D000E2A10 /* CategoryManagementViewModel.swift */; };
 		B9AB12352F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
 		B9AB12362F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
 		B9AB12372F9C000000000001 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AB12342F9C000000000001 /* AppLogger.swift */; };
@@ -151,6 +157,8 @@
 		B96CBAAE2E51BF7800DB2E48 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		B99ABA6C2FA1DEA3000E2A10 /* CategoryInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryInfo.swift; sourceTree = "<group>"; };
 		B99ABA702FA1DEB6000E2A10 /* CategoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRepository.swift; sourceTree = "<group>"; };
+		B99ABA752FA1E97A000E2A10 /* CategoryManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryManagementView.swift; sourceTree = "<group>"; };
+		B99ABA792FA1E98D000E2A10 /* CategoryManagementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryManagementViewModel.swift; sourceTree = "<group>"; };
 		B9AB12342F9C000000000001 /* AppLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogger.swift; sourceTree = "<group>"; };
 		B9AB12382F9C000000000002 /* ViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
 		B9B00CCC2E518DED00BCB306 /* imitate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = imitate.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -213,6 +221,7 @@
 			children = (
 				B9329E052F8ED5E7000797AB /* TopHomeViewModel.swift */,
 				B95E7F592F8558C10071D91A /* HistoryHomeViewModel.swift */,
+				B99ABA792FA1E98D000E2A10 /* CategoryManagementViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -305,6 +314,7 @@
 			children = (
 				B9C191A32EFFDBD200AFE3C3 /* BaseHomeView.swift */,
 				B9C191B32EFFDCD100AFE3C3 /* TopHomeView.swift */,
+				B99ABA752FA1E97A000E2A10 /* CategoryManagementView.swift */,
 				B9C191B82EFFDDB700AFE3C3 /* InputHomeView.swift */,
 				B9C191BC2EFFDE3000AFE3C3 /* GameHomeView.swift */,
 				B9C191C02EFFDE4E00AFE3C3 /* HistoryHomeView.swift */,
@@ -549,8 +559,10 @@
 				B95E7F5B2F8558C10071D91A /* HistoryHomeViewModel.swift in Sources */,
 				B9B00CD02E518DED00BCB306 /* imitateApp.swift in Sources */,
 				B99ABA6D2FA1DEA3000E2A10 /* CategoryInfo.swift in Sources */,
+				B99ABA7A2FA1E98D000E2A10 /* CategoryManagementViewModel.swift in Sources */,
 				B95E7F5E2F8558C10071D91A /* HistoryInfoMapper.swift in Sources */,
 				B9C191CA2EFFF4C500AFE3C3 /* BalanceView.swift in Sources */,
+				B99ABA762FA1E97A000E2A10 /* CategoryManagementView.swift in Sources */,
 				B9C191D12F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */,
 				B96CBAAF2E51BF7800DB2E48 /* SceneDelegate.swift in Sources */,
 				B9E0D79A2F85344B00CF247C /* DictionaryExtension.swift in Sources */,
@@ -573,8 +585,10 @@
 				B95E7F672F8558D70071D91A /* HistoryInfoMapperTests.swift in Sources */,
 				B9C191B52EFFDCD100AFE3C3 /* TopHomeView.swift in Sources */,
 				B9C191A72EFFDC2400AFE3C3 /* BaseHomeView.swift in Sources */,
+				B99ABA7B2FA1E98D000E2A10 /* CategoryManagementViewModel.swift in Sources */,
 				B9C191A92EFFDC2A00AFE3C3 /* SceneDelegate.swift in Sources */,
 				B9E0D79B2F85344B00CF247C /* DictionaryExtension.swift in Sources */,
+				B99ABA772FA1E97A000E2A10 /* CategoryManagementView.swift in Sources */,
 				B9C191C62EFFDE6400AFE3C3 /* SettingHomeView.swift in Sources */,
 				B9329E072F8ED5E7000797AB /* TopHomeViewModel.swift in Sources */,
 				B9DEC55B2F1D538B0085FEC5 /* HistoryRowView.swift in Sources */,
@@ -626,8 +640,10 @@
 				B9C191C72EFFDE6400AFE3C3 /* SettingHomeView.swift in Sources */,
 				B9C191BF2EFFDE3000AFE3C3 /* GameHomeView.swift in Sources */,
 				B9C166642F267E7600A3BEC5 /* BalanceRecordInfo.swift in Sources */,
+				B99ABA7C2FA1E98D000E2A10 /* CategoryManagementViewModel.swift in Sources */,
 				B99ABA732FA1DEB6000E2A10 /* CategoryRepository.swift in Sources */,
 				B95E7F5D2F8558C10071D91A /* HistoryHomeViewModel.swift in Sources */,
+				B99ABA782FA1E97A000E2A10 /* CategoryManagementView.swift in Sources */,
 				B9C191CC2EFFF4C500AFE3C3 /* BalanceView.swift in Sources */,
 				B9C191D32F0A000000AFE3C3 /* BalanceGraphView.swift in Sources */,
 			);

--- a/project/iOS/imitate/Screen/HomeView/CategoryManagementView.swift
+++ b/project/iOS/imitate/Screen/HomeView/CategoryManagementView.swift
@@ -1,0 +1,119 @@
+//
+//  CategoryManagementView.swift
+//  imitate
+//
+//  Created by garigari0118 on 2026/04/29.
+//
+
+import SwiftUI
+
+struct CategoryManagementView: View {
+
+    @StateObject private var viewModel = CategoryManagementViewModel()
+
+    @State private var selectedType: CategoryType = .income
+    @State private var showAddAlert = false
+    @State private var showEditAlert = false
+    @State private var showActionSheet = false
+    @State private var editingCategory: CategoryInfo? = nil
+    @State private var inputName = ""
+
+    private var currentCategories: [CategoryInfo] {
+        switch selectedType {
+        case .income:   return viewModel.incomeCategories
+        case .expense:  return viewModel.expenseCategories
+        }
+    }
+
+    var body: some View {
+        Group {
+            switch viewModel.viewState {
+            case .loading:
+                ProgressView()
+            case .loaded:
+                loadedView
+            case .error:
+                Text("カテゴリの取得に失敗しました")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle("カテゴリ管理")
+        .navigationBarTitleDisplayMode(.inline)
+        .alert("カテゴリを追加", isPresented: $showAddAlert) {
+            TextField("カテゴリ名", text: $inputName)
+            Button("追加") {
+                let name = inputName.trimmingCharacters(in: .whitespaces)
+                if !name.isEmpty {
+                    viewModel.addCategory(name: name, type: selectedType)
+                }
+            }
+            Button("キャンセル", role: .cancel) {}
+        }
+        .alert("カテゴリ名を変更", isPresented: $showEditAlert) {
+            TextField("カテゴリ名", text: $inputName)
+            Button("保存") {
+                let name = inputName.trimmingCharacters(in: .whitespaces)
+                if let id = editingCategory?.id, !name.isEmpty {
+                    viewModel.updateCategory(id: id, name: name)
+                }
+            }
+            Button("キャンセル", role: .cancel) {}
+        }
+        .confirmationDialog("操作を選択", isPresented: $showActionSheet, titleVisibility: .hidden) {
+            Button("編集") {
+                inputName = editingCategory?.name ?? ""
+                showEditAlert = true
+            }
+            if currentCategories.count > 1 {
+                Button("削除", role: .destructive) {
+                    if let id = editingCategory?.id {
+                        viewModel.deleteCategory(id: id, type: selectedType)
+                    }
+                }
+            }
+            Button("キャンセル", role: .cancel) {}
+        }
+        .onAppear {
+            viewModel.fetchCategories()
+        }
+    }
+
+    private var loadedView: some View {
+        VStack(spacing: 0) {
+            Picker("種類", selection: $selectedType) {
+                Text("収入").tag(CategoryType.income)
+                Text("支出").tag(CategoryType.expense)
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            List {
+                Section {
+                    ForEach(currentCategories, id: \.id) { category in
+                        Button {
+                            editingCategory = category
+                            showActionSheet = true
+                        } label: {
+                            Text(category.name ?? "")
+                                .foregroundStyle(.black)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                    Button {
+                        inputName = ""
+                        showAddAlert = true
+                    } label: {
+                        Label("カテゴリを追加", systemImage: "plus")
+                            .foregroundStyle(.black)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        CategoryManagementView()
+    }
+}

--- a/project/iOS/imitate/Screen/HomeView/SettingHomeView.swift
+++ b/project/iOS/imitate/Screen/HomeView/SettingHomeView.swift
@@ -9,8 +9,25 @@ import SwiftUI
 
 struct SettingHomeView: View {
     var body: some View {
-        Text("SettingHomeView")
+        NavigationStack {
+            List {
+                Section("データ管理") {
+                    NavigationLink {
+                        CategoryManagementView()
+                    } label: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("カテゴリ管理")
+                                .font(.headline)
+                            Text("収入・支出のカテゴリを追加・編集・削除できます")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("設定")
             .logScreenAppeared()
+        }
     }
 }
 

--- a/project/iOS/imitate/ViewModel/CategoryManagementViewModel.swift
+++ b/project/iOS/imitate/ViewModel/CategoryManagementViewModel.swift
@@ -1,0 +1,68 @@
+//
+//  CategoryManagementViewModel.swift
+//  imitate
+//
+//  Created by garigari0118 on 2026/04/29.
+//
+
+import Foundation
+
+class CategoryManagementViewModel: ObservableObject {
+
+    enum ViewState {
+        case loading
+        case loaded
+        case error
+    }
+
+    private enum FetchError: Error {
+        case failed
+    }
+
+    @Published var viewState: ViewState = .loading
+    @Published var incomeCategories: [CategoryInfo] = []
+    @Published var expenseCategories: [CategoryInfo] = []
+
+    func fetchCategories() {
+        Task { @MainActor in
+            viewState = .loading
+            do {
+                async let income = getCategories(type: .income)
+                async let expense = getCategories(type: .expense)
+                incomeCategories = try await income
+                expenseCategories = try await expense
+                viewState = .loaded
+            } catch {
+                viewState = .error
+            }
+        }
+    }
+
+    func addCategory(name: String, type: CategoryType) {
+        CategoryRepository.shared.addCategory(name: name, type: type) { [weak self] _ in
+            self?.fetchCategories()
+        } onFailure: {}
+    }
+
+    func updateCategory(id: Int, name: String) {
+        CategoryRepository.shared.updateCategory(id: id, name: name) { [weak self] in
+            self?.fetchCategories()
+        } onFailure: {}
+    }
+
+    func deleteCategory(id: Int, type: CategoryType) {
+        CategoryRepository.shared.deleteCategory(id: id) { [weak self] in
+            self?.fetchCategories()
+        } onFailure: {}
+    }
+
+    private func getCategories(type: CategoryType) async throws -> [CategoryInfo] {
+        try await withCheckedThrowingContinuation { continuation in
+            CategoryRepository.shared.getCategories(type: type) { categories in
+                continuation.resume(returning: categories)
+            } onFailure: {
+                continuation.resume(throwing: FetchError.failed)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 設定画面からカテゴリの追加・編集・削除ができるカテゴリ管理画面を追加
- カテゴリ取得に async/await を採用し DispatchGroup を廃止

## 変更内容

### 新規作成
- `CategoryManagementView.swift` — カテゴリ管理画面
  - セグメントで収入/支出を切替（スクロールに影響されない固定表示）
  - タップでアクションシート（編集・削除）を表示
  - カテゴリが1件の場合は削除不可
  - リスト末尾の「カテゴリを追加」ボタンで追加
- `CategoryManagementViewModel.swift` — カテゴリ管理ViewModel
  - `async let` で収入・支出カテゴリを並列取得
  - `loading / loaded / error` の状態管理

### 変更
- `SettingHomeView.swift` — カテゴリ管理への導線を追加（タイトル・説明文付き）

## Test plan
- [ ] 設定画面から「カテゴリ管理」に遷移できる
- [ ] 収入・支出のセグメントが切り替わる
- [ ] カテゴリをタップするとアクションシートが表示される
- [ ] カテゴリ名を編集できる
- [ ] カテゴリを削除できる（1件の場合は削除不可）
- [ ] カテゴリを追加できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)